### PR TITLE
ci: remove python3-flux sub-package references from CI

### DIFF
--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -30,7 +30,7 @@ runs:
         mock -r ${{ inputs.mock-release }} --install $SECURITY_RPMS
 
         echo "=== Installing flux-core packages ==="
-        CORE_RPMS=$(ls ${{ inputs.core-results }}/flux-core*.x86_64.rpm ${{ inputs.core-results }}/python3-flux*.x86_64.rpm 2>/dev/null | grep -v debuginfo | grep -v debugsource)
+        CORE_RPMS=$(ls ${{ inputs.core-results }}/flux-core*.x86_64.rpm 2>/dev/null | grep -v debuginfo | grep -v debugsource)
         echo "Installing: $CORE_RPMS"
         mock -r ${{ inputs.mock-release }} --install $CORE_RPMS
 
@@ -87,7 +87,6 @@ runs:
           echo "--- Package info ---"
           rpm -qi flux-core
           rpm -qi flux-core-devel
-          rpm -qi python3-flux
 
           echo ""
           echo "--- Binary verification ---"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -295,10 +295,9 @@ jobs:
         run: |
           CORE_RPM=$(ls results-core/flux-core-[0-9]*.x86_64.rpm | head -1)
           CORE_DEVEL_RPM=$(ls results-core/flux-core-devel-*.x86_64.rpm | head -1)
-          PYTHON_RPM=$(ls results-core/python3-flux-[0-9]*.x86_64.rpm | head -1)
-          echo "Installing: $CORE_RPM $CORE_DEVEL_RPM $PYTHON_RPM"
+          echo "Installing: $CORE_RPM $CORE_DEVEL_RPM"
           # Use --no-clean and --no-cleanup-after to preserve chroot state
-          mock -r ${{ matrix.mock-release }} --no-clean --no-cleanup-after --install "$CORE_RPM" "$CORE_DEVEL_RPM" "$PYTHON_RPM"
+          mock -r ${{ matrix.mock-release }} --no-clean --no-cleanup-after --install "$CORE_RPM" "$CORE_DEVEL_RPM"
 
       # ============================================================
       # Build flux-sched and flux-accounting in parallel (both depend only on core)
@@ -316,15 +315,14 @@ jobs:
           SECURITY_DEVEL_RPM=$(ls results-security/flux-security-devel-*.x86_64.rpm | head -1)
           CORE_RPM=$(ls results-core/flux-core-[0-9]*.x86_64.rpm | head -1)
           CORE_DEVEL_RPM=$(ls results-core/flux-core-devel-*.x86_64.rpm | head -1)
-          PYTHON_RPM=$(ls results-core/python3-flux-[0-9]*.x86_64.rpm | head -1)
           
           echo "Installing dependencies into accounting chroot:"
           echo "  $SECURITY_RPM $SECURITY_DEVEL_RPM"
-          echo "  $CORE_RPM $CORE_DEVEL_RPM $PYTHON_RPM"
+          echo "  $CORE_RPM $CORE_DEVEL_RPM"
           
           mock -r ${{ matrix.mock-release }} --uniqueext=accounting \
             --no-clean --no-cleanup-after \
-            --install "$SECURITY_RPM" "$SECURITY_DEVEL_RPM" "$CORE_RPM" "$CORE_DEVEL_RPM" "$PYTHON_RPM"
+            --install "$SECURITY_RPM" "$SECURITY_DEVEL_RPM" "$CORE_RPM" "$CORE_DEVEL_RPM"
           
           # Copy ccache data to the accounting chroot
           CCACHE_SRC="/var/lib/mock/${{ matrix.mock-release }}/root/root/.ccache"
@@ -502,12 +500,11 @@ jobs:
           dnf install -y --skip-broken \
             rpms/results-security/flux-security-[0-9]*.x86_64.rpm \
             rpms/results-core/flux-core-[0-9]*.x86_64.rpm \
-            rpms/results-core/python3-flux-[0-9]*.x86_64.rpm \
             rpms/results-sched/flux-sched-[0-9]*.x86_64.rpm \
             rpms/results-accounting/flux-accounting-[0-9]*.x86_64.rpm
           
           echo "=== Installed Flux packages ==="
-          rpm -qa | grep -E '^(flux|python3-flux)' | sort
+          rpm -qa | grep -E '^flux' | sort
 
       - name: Setup test environment
         run: |
@@ -694,7 +691,7 @@ jobs:
           echo "Date: $(date)" >> smoke-test-summary.txt
           echo "" >> smoke-test-summary.txt
           echo "Installed packages:" >> smoke-test-summary.txt
-          rpm -qa | grep -E '^(flux|python3-flux)' | sort >> smoke-test-summary.txt
+          rpm -qa | grep -E '^flux' | sort >> smoke-test-summary.txt
           echo "" >> smoke-test-summary.txt
           echo "All smoke tests passed!" >> smoke-test-summary.txt
 

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -523,7 +523,7 @@ jobs:
             - Full GitHub Source URL
             - Removed deprecated tags (BuildRoot, Group, %defattr, %clean)
             - Modern ldconfig scriptlets
-            - Removed versioned Python subpackages (use `python3-flux`)
+            - Python bindings included in main `flux-core` package
             - Removed LLNL-specific patches and conditionals
             - Modern build macros (`%make_build`, `%make_install`)
             - Corrected `flux-security-devel` dependency

--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -41,7 +41,6 @@ BuildRequires: systemd-rpm-macros
 BuildRequires: glibc-langpack-en
 
 Requires: flux-core
-Requires: python3-flux
 Requires: sqlite >= 3.6.0
 Requires: python3
 Requires: python3-cffi

--- a/flux-core/flux-core.rpmlintrc
+++ b/flux-core/flux-core.rpmlintrc
@@ -9,6 +9,3 @@ addFilter("cross-directory-hard-link")
 
 # flux-python is a wrapper script, manpage is not essential
 addFilter("no-manual-page-for-binary flux-python")
-
-# python3-flux subpackage documentation is in main package
-addFilter("no-documentation.*python3-flux")


### PR DESCRIPTION
## Summary

- Remove all references to the `python3-flux` RPM from CI workflows and test actions, since PR #2 merged the sub-package into the main `flux-core` RPM.
- Fixes the Build job failures caused by `ls` failing to find `python3-flux-*.x86_64.rpm` and passing an empty string to `mock --install`.

### Changes

- **`build-test.yml`**: Remove `PYTHON_RPM` variable from "Install flux-core in mock" and "Prepare parallel build chroot" steps; remove `python3-flux` glob from smoke test `dnf install`; simplify `rpm -qa` grep patterns.
- **`test-packages/action.yml`**: Remove `python3-flux` glob from core RPM install step; remove `rpm -qi python3-flux` from verification test.
- **`check-updates.yml`**: Update documentation comment to reflect that Python bindings are now part of the main `flux-core` package.

## Test plan

- [ ] All 6 Build matrix jobs (fedora-41, fedora-42, fedora-43, fedora-rawhide, centos-9, centos-10) pass
- [ ] Smoke tests run successfully

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Update CI workflows and shared test action to stop referencing the deprecated python3-flux subpackage now that Python bindings are bundled in the main flux-core RPM.

Bug Fixes:
- Resolve build job failures caused by attempting to install non-existent python3-flux RPMs in mock chroots.

CI:
- Remove python3-flux RPM discovery and installation from build-test workflow install and parallel chroot setup steps.
- Simplify smoke-test package installation and reporting to only target flux-core-related packages.
- Update check-updates workflow documentation to reflect that Python bindings are shipped with the main flux-core package.

Tests:
- Adjust reusable test-packages action to install only flux-core RPMs and drop verification of the removed python3-flux package.