### PR TITLE
Bump all flux packages to latest; add COPR auto-trigger

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -211,9 +211,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - distro: fedora-41
-            mock-release: fedora-41-x86_64
-            short-name: f41
           - distro: fedora-42
             mock-release: fedora-42-x86_64
             short-name: f42
@@ -458,9 +455,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - distro: fedora-41
-            image: fedora:41
-            short-name: f41
           - distro: fedora-42
             image: fedora:42
             short-name: f42

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -200,7 +200,7 @@ jobs:
           # Move to workspace for upload
           mkdir -p srpms
           mv ~/rpmbuild/SRPMS/*.src.rpm srpms/
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: srpms
           path: srpms/
@@ -244,34 +244,16 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download SRPMs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: srpms
           path: ./srpms
 
-      - name: Restore mock cache
-        uses: actions/cache@v5
-        with:
-          path: /var/cache/mock
-          key: mock-${{ matrix.mock-release }}-${{ hashFiles('flux-*/*.spec') }}
-          restore-keys: |
-            mock-${{ matrix.mock-release }}-
-
       - name: List SRPMs
         run: ls -la ./srpms/
 
-      - name: Initialize mock with ccache
-        run: |
-          # Initialize mock with ccache plugin enabled
-          # Mock's ccache plugin stores data at /var/cache/mock/<chroot>/ccache/
-          # which is included in our mock cache restore above
-          mock -r ${{ matrix.mock-release }} --enable-plugin=ccache --init
-          
-          echo "=== Mock ccache location ==="
-          ls -la /var/cache/mock/${{ matrix.mock-release }}/ccache/ 2>/dev/null || echo "ccache dir not yet created"
-          
-          echo "=== Checking ccache stats after init ==="
-          mock -r ${{ matrix.mock-release }} --chroot -- ccache --show-stats 2>/dev/null || true
+      - name: Initialize mock
+        run: mock -r ${{ matrix.mock-release }} --init
 
       # ============================================================
       # Build flux-security
@@ -279,7 +261,7 @@ jobs:
       - name: Build flux-security
         run: |
           set -o pipefail
-          mock -r ${{ matrix.mock-release }} --enable-plugin=ccache --no-clean --no-cleanup-after --rebuild srpms/flux-security-*.src.rpm --resultdir=results-security 2>&1 | tee security-build.log
+          mock -r ${{ matrix.mock-release }} --no-clean --no-cleanup-after --rebuild srpms/flux-security-*.src.rpm --resultdir=results-security 2>&1 | tee security-build.log
 
       - name: Install flux-security in mock
         run: |
@@ -295,7 +277,7 @@ jobs:
       - name: Build flux-core
         run: |
           set -o pipefail
-          mock -r ${{ matrix.mock-release }} --enable-plugin=ccache --no-clean --no-cleanup-after --rebuild srpms/flux-core-*.src.rpm --resultdir=results-core 2>&1 | tee core-build.log
+          mock -r ${{ matrix.mock-release }} --no-clean --no-cleanup-after --rebuild srpms/flux-core-*.src.rpm --resultdir=results-core 2>&1 | tee core-build.log
 
       - name: Install flux-core in mock
         run: |
@@ -312,56 +294,32 @@ jobs:
       # Prepare a separate chroot for flux-accounting (needed to avoid mock lock contention)
       - name: Prepare parallel build chroot for flux-accounting
         run: |
-          echo "=== Initializing separate chroot for flux-accounting ==="
-          # Initialize a separate chroot with ccache
-          mock -r ${{ matrix.mock-release }} --uniqueext=accounting --enable-plugin=ccache --init
+          mock -r ${{ matrix.mock-release }} --uniqueext=accounting --init
           
-          # Install flux-security and flux-core into the accounting chroot
           SECURITY_RPM=$(ls results-security/flux-security-[0-9]*.x86_64.rpm | head -1)
           SECURITY_DEVEL_RPM=$(ls results-security/flux-security-devel-*.x86_64.rpm | head -1)
           CORE_RPM=$(ls results-core/flux-core-[0-9]*.x86_64.rpm | head -1)
           CORE_DEVEL_RPM=$(ls results-core/flux-core-devel-*.x86_64.rpm | head -1)
           
-          echo "Installing dependencies into accounting chroot:"
-          echo "  $SECURITY_RPM $SECURITY_DEVEL_RPM"
-          echo "  $CORE_RPM $CORE_DEVEL_RPM"
-          
           mock -r ${{ matrix.mock-release }} --uniqueext=accounting \
             --no-clean --no-cleanup-after \
             --install "$SECURITY_RPM" "$SECURITY_DEVEL_RPM" "$CORE_RPM" "$CORE_DEVEL_RPM"
-          
-          # Copy ccache data to the accounting chroot
-          CCACHE_SRC="/var/lib/mock/${{ matrix.mock-release }}/root/root/.ccache"
-          CCACHE_DST="/var/lib/mock/${{ matrix.mock-release }}-accounting/root/root/.ccache"
-          if [ -d "$CCACHE_SRC" ]; then
-            mkdir -p "$CCACHE_DST"
-            cp -r "$CCACHE_SRC"/* "$CCACHE_DST"/ 2>/dev/null || true
-            echo "Copied ccache to accounting chroot"
-          fi
 
       - name: Build flux-sched and flux-accounting (parallel)
         run: |
           set -o pipefail
           
-          # Build flux-sched in the main chroot (background)
-          echo "=== Starting flux-sched build (background) ==="
-          mock -r ${{ matrix.mock-release }} --enable-plugin=ccache \
+          mock -r ${{ matrix.mock-release }} \
             --no-clean --no-cleanup-after \
             --rebuild srpms/flux-sched-*.src.rpm \
             --resultdir=results-sched 2>&1 | tee sched-build.log &
           SCHED_PID=$!
           
-          # Build flux-accounting in the separate chroot (background)
-          echo "=== Starting flux-accounting build (background) ==="
-          mock -r ${{ matrix.mock-release }} --uniqueext=accounting --enable-plugin=ccache \
+          mock -r ${{ matrix.mock-release }} --uniqueext=accounting \
             --no-clean --no-cleanup-after \
             --rebuild srpms/flux-accounting-*.src.rpm \
             --resultdir=results-accounting 2>&1 | tee accounting-build.log &
           ACCT_PID=$!
-          
-          echo "=== Waiting for parallel builds to complete ==="
-          echo "flux-sched PID: $SCHED_PID"
-          echo "flux-accounting PID: $ACCT_PID"
           
           # Wait for both builds and capture exit codes
           SCHED_EXIT=0
@@ -394,9 +352,6 @@ jobs:
           echo "=== Build Summary for ${{ matrix.mock-release }} ===" | tee build-summary.txt
           echo "Build completed: $(date)" >> build-summary.txt
           echo "" >> build-summary.txt
-          echo "=== ccache stats ===" >> build-summary.txt
-          mock -r ${{ matrix.mock-release }} --enable-plugin=ccache --chroot -- ccache --show-stats 2>/dev/null >> build-summary.txt || echo "ccache stats not available" >> build-summary.txt
-          echo "" >> build-summary.txt
           echo "=== flux-security packages ===" >> build-summary.txt
           ls -la results-security/*.rpm 2>/dev/null | grep -v debuginfo >> build-summary.txt || echo "No packages" >> build-summary.txt
           echo "" >> build-summary.txt
@@ -410,7 +365,7 @@ jobs:
           ls -la results-accounting/*.rpm 2>/dev/null | grep -v debuginfo >> build-summary.txt || echo "No packages" >> build-summary.txt
 
       - name: Upload all build results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: rpms-${{ matrix.short-name }}
@@ -421,26 +376,6 @@ jobs:
             results-accounting/
             *-build.log
             build-summary.txt
-
-      # Show final ccache stats before cleanup
-      # Mock's ccache plugin stores data at /var/cache/mock/<chroot>/ccache/
-      # which is automatically saved by our mock cache step above
-      - name: Show final ccache stats
-        if: always()
-        run: |
-          echo "=== Final ccache statistics ==="
-          CCACHE_DIR=/var/cache/mock/${{ matrix.mock-release }}/ccache/u0
-          if [ -d "$CCACHE_DIR" ]; then
-            CCACHE_DIR=$CCACHE_DIR ccache --show-stats 2>/dev/null || ccache -s 2>/dev/null || echo "ccache stats not available"
-          else
-            echo "ccache directory not found at $CCACHE_DIR"
-          fi
-          
-          echo "=== Mock ccache directory size ==="
-          du -sh /var/cache/mock/${{ matrix.mock-release }}/ccache/ 2>/dev/null || echo "ccache dir not found"
-          
-          echo "=== Cache contents ==="
-          find /var/cache/mock/${{ matrix.mock-release }}/ccache/ -type f 2>/dev/null | wc -l | xargs -I {} echo "Total cached files: {}"
 
       - name: Cleanup mock
         if: always()
@@ -485,7 +420,7 @@ jobs:
 
     steps:
       - name: Download RPMs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: rpms-${{ matrix.short-name }}
           path: ./rpms
@@ -699,7 +634,7 @@ jobs:
           echo "All smoke tests passed!" >> smoke-test-summary.txt
 
       - name: Upload smoke test results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: smoke-test-${{ matrix.short-name }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'flux-*/*.spec'
+      - 'flux-*/sources'
+      - 'flux-*/*.patch'
+      - '.copr/**'
+      - '.github/workflows/build-test.yml'
+      - '.github/workflows/reusable-mock-build.yml'
+      - '.github/actions/**'
+      - '.github/containers/**'
   workflow_dispatch:
 
 # Cancel in-progress runs when a new run is triggered

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,7 +32,7 @@ jobs:
     name: Spelling check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check Spelling
         uses: crate-ci/typos@v1.28.4
         with:
@@ -42,7 +42,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run shellcheck on scripts
         uses: ludeeus/action-shellcheck@master
         with:
@@ -56,7 +56,7 @@ jobs:
     container:
       image: fedora:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install rpmlint with config files
         run: |
           dnf install -y rpmlint
@@ -94,7 +94,7 @@ jobs:
     container:
       image: fedora:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install rpmspec
         run: dnf install -y rpm-build
       
@@ -158,7 +158,7 @@ jobs:
     container:
       image: fedora:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build all SRPMs
         run: |
           dnf install -y rpm-build rpmdevtools wget
@@ -200,7 +200,7 @@ jobs:
           # Move to workspace for upload
           mkdir -p srpms
           mv ~/rpmbuild/SRPMS/*.src.rpm srpms/
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: srpms
           path: srpms/
@@ -241,16 +241,16 @@ jobs:
       options: --privileged
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download SRPMs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: srpms
           path: ./srpms
 
       - name: Restore mock cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /var/cache/mock
           key: mock-${{ matrix.mock-release }}-${{ hashFiles('flux-*/*.spec') }}
@@ -410,7 +410,7 @@ jobs:
           ls -la results-accounting/*.rpm 2>/dev/null | grep -v debuginfo >> build-summary.txt || echo "No packages" >> build-summary.txt
 
       - name: Upload all build results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: rpms-${{ matrix.short-name }}
@@ -485,7 +485,7 @@ jobs:
 
     steps:
       - name: Download RPMs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: rpms-${{ matrix.short-name }}
           path: ./rpms
@@ -699,7 +699,7 @@ jobs:
           echo "All smoke tests passed!" >> smoke-test-summary.txt
 
       - name: Upload smoke test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: smoke-test-${{ matrix.short-name }}

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -281,7 +281,6 @@ jobs:
           EOF
 
       - name: Create tracking issue
-        id: create-issue
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "Update flux-security to ${{ needs.check-flux-security.outputs.new_version }}"
@@ -299,8 +298,6 @@ jobs:
             Automated version bump for flux-security from ${{ needs.check-flux-security.outputs.current_version }} to ${{ needs.check-flux-security.outputs.new_version }}.
 
             Release: https://github.com/flux-framework/flux-security/releases/tag/v${{ needs.check-flux-security.outputs.new_version }}
-
-            Closes #${{ steps.create-issue.outputs.issue-number }}
 
             Please review:
             - [ ] Check release notes for spec file changes
@@ -344,7 +341,6 @@ jobs:
           EOF
 
       - name: Create tracking issue
-        id: create-issue
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "Update flux-core to ${{ needs.check-flux-core.outputs.new_version }}"
@@ -362,8 +358,6 @@ jobs:
             Automated version bump for flux-core from ${{ needs.check-flux-core.outputs.current_version }} to ${{ needs.check-flux-core.outputs.new_version }}.
 
             Release: https://github.com/flux-framework/flux-core/releases/tag/v${{ needs.check-flux-core.outputs.new_version }}
-
-            Closes #${{ steps.create-issue.outputs.issue-number }}
 
             Please review:
             - [ ] Check release notes for spec file changes
@@ -407,7 +401,6 @@ jobs:
           EOF
 
       - name: Create tracking issue
-        id: create-issue
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "Update flux-sched to ${{ needs.check-flux-sched.outputs.new_version }}"
@@ -425,8 +418,6 @@ jobs:
             Automated version bump for flux-sched from ${{ needs.check-flux-sched.outputs.current_version }} to ${{ needs.check-flux-sched.outputs.new_version }}.
 
             Release: https://github.com/flux-framework/flux-sched/releases/tag/v${{ needs.check-flux-sched.outputs.new_version }}
-
-            Closes #${{ steps.create-issue.outputs.issue-number }}
 
             Please review:
             - [ ] Check release notes for spec file changes
@@ -470,7 +461,6 @@ jobs:
           EOF
 
       - name: Create tracking issue
-        id: create-issue
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "Update flux-accounting to ${{ needs.check-flux-accounting.outputs.new_version }}"
@@ -488,8 +478,6 @@ jobs:
             Automated version bump for flux-accounting from ${{ needs.check-flux-accounting.outputs.current_version }} to ${{ needs.check-flux-accounting.outputs.new_version }}.
 
             Release: https://github.com/flux-framework/flux-accounting/releases/tag/v${{ needs.check-flux-accounting.outputs.new_version }}
-
-            Closes #${{ steps.create-issue.outputs.issue-number }}
 
             Please review:
             - [ ] Check release notes for spec file changes

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -26,7 +26,7 @@ jobs:
       new_version: ${{ steps.check.outputs.new_version }}
       current_version: ${{ steps.check.outputs.current_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get current version
         id: current
@@ -82,7 +82,7 @@ jobs:
       new_version: ${{ steps.check.outputs.new_version }}
       current_version: ${{ steps.check.outputs.current_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get current version
         id: current
@@ -138,7 +138,7 @@ jobs:
       new_version: ${{ steps.check.outputs.new_version }}
       current_version: ${{ steps.check.outputs.current_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get current version
         id: current
@@ -194,7 +194,7 @@ jobs:
       new_version: ${{ steps.check.outputs.new_version }}
       current_version: ${{ steps.check.outputs.current_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get current version
         id: current
@@ -254,7 +254,7 @@ jobs:
     if: needs.check-flux-security.outputs.new_version != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Update spec and sources
         run: |
@@ -292,7 +292,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update flux-security to ${{ needs.check-flux-security.outputs.new_version }}"
@@ -319,7 +319,7 @@ jobs:
     if: needs.check-flux-core.outputs.new_version != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Update spec and sources
         run: |
@@ -357,7 +357,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update flux-core to ${{ needs.check-flux-core.outputs.new_version }}"
@@ -384,7 +384,7 @@ jobs:
     if: needs.check-flux-sched.outputs.new_version != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Update spec and sources
         run: |
@@ -422,7 +422,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update flux-sched to ${{ needs.check-flux-sched.outputs.new_version }}"
@@ -449,7 +449,7 @@ jobs:
     if: needs.check-flux-accounting.outputs.new_version != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Update spec and sources
         run: |
@@ -487,7 +487,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update flux-accounting to ${{ needs.check-flux-accounting.outputs.new_version }}"

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -281,6 +281,7 @@ jobs:
           EOF
 
       - name: Create tracking issue
+        id: create-issue
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "Update flux-security to ${{ needs.check-flux-security.outputs.new_version }}"
@@ -298,6 +299,8 @@ jobs:
             Automated version bump for flux-security from ${{ needs.check-flux-security.outputs.current_version }} to ${{ needs.check-flux-security.outputs.new_version }}.
 
             Release: https://github.com/flux-framework/flux-security/releases/tag/v${{ needs.check-flux-security.outputs.new_version }}
+
+            Closes #${{ steps.create-issue.outputs.issue-number }}
 
             Please review:
             - [ ] Check release notes for spec file changes
@@ -341,6 +344,7 @@ jobs:
           EOF
 
       - name: Create tracking issue
+        id: create-issue
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "Update flux-core to ${{ needs.check-flux-core.outputs.new_version }}"
@@ -358,6 +362,8 @@ jobs:
             Automated version bump for flux-core from ${{ needs.check-flux-core.outputs.current_version }} to ${{ needs.check-flux-core.outputs.new_version }}.
 
             Release: https://github.com/flux-framework/flux-core/releases/tag/v${{ needs.check-flux-core.outputs.new_version }}
+
+            Closes #${{ steps.create-issue.outputs.issue-number }}
 
             Please review:
             - [ ] Check release notes for spec file changes
@@ -401,6 +407,7 @@ jobs:
           EOF
 
       - name: Create tracking issue
+        id: create-issue
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "Update flux-sched to ${{ needs.check-flux-sched.outputs.new_version }}"
@@ -418,6 +425,8 @@ jobs:
             Automated version bump for flux-sched from ${{ needs.check-flux-sched.outputs.current_version }} to ${{ needs.check-flux-sched.outputs.new_version }}.
 
             Release: https://github.com/flux-framework/flux-sched/releases/tag/v${{ needs.check-flux-sched.outputs.new_version }}
+
+            Closes #${{ steps.create-issue.outputs.issue-number }}
 
             Please review:
             - [ ] Check release notes for spec file changes
@@ -461,6 +470,7 @@ jobs:
           EOF
 
       - name: Create tracking issue
+        id: create-issue
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "Update flux-accounting to ${{ needs.check-flux-accounting.outputs.new_version }}"
@@ -478,6 +488,8 @@ jobs:
             Automated version bump for flux-accounting from ${{ needs.check-flux-accounting.outputs.current_version }} to ${{ needs.check-flux-accounting.outputs.new_version }}.
 
             Release: https://github.com/flux-framework/flux-accounting/releases/tag/v${{ needs.check-flux-accounting.outputs.new_version }}
+
+            Closes #${{ steps.create-issue.outputs.issue-number }}
 
             Please review:
             - [ ] Check release notes for spec file changes

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -263,10 +263,18 @@ jobs:
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-security/releases/download/v${VERSION}/flux-security-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-security-${VERSION}.tar.gz) = ${SHA256}" > flux-security/sources
 
-      - name: Write issue body
+      - name: Find or create tracking issue
+        id: create-issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cat > /tmp/issue-body.md << 'EOF'
-          New flux-security release detected.
+          TITLE="Update flux-security to ${{ needs.check-flux-security.outputs.new_version }}"
+          EXISTING=$(gh issue list --search "$TITLE" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "issue-number=$EXISTING" >> "$GITHUB_OUTPUT"
+            echo "Reusing existing issue #$EXISTING"
+          else
+            BODY="New flux-security release detected.
 
           **Current version:** ${{ needs.check-flux-security.outputs.current_version }}
           **New version:** ${{ needs.check-flux-security.outputs.new_version }}
@@ -277,17 +285,11 @@ jobs:
           - [ ] Verify patches are still needed for this version
           - [ ] Verify BuildRequires are still correct
           - [ ] Test build locally if possible
-          - [ ] Add changelog entry
-          EOF
-
-      - name: Create tracking issue
-        id: create-issue
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: "Update flux-security to ${{ needs.check-flux-security.outputs.new_version }}"
-          content-filepath: /tmp/issue-body.md
-          labels: enhancement,flux-security
-        continue-on-error: true
+          - [ ] Add changelog entry"
+            NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-security | grep -oP '\d+$')
+            echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
+            echo "Created issue #$NUM"
+          fi
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
@@ -326,10 +328,18 @@ jobs:
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-core/releases/download/v${VERSION}/flux-core-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-core-${VERSION}.tar.gz) = ${SHA256}" > flux-core/sources
 
-      - name: Write issue body
+      - name: Find or create tracking issue
+        id: create-issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cat > /tmp/issue-body.md << 'EOF'
-          New flux-core release detected.
+          TITLE="Update flux-core to ${{ needs.check-flux-core.outputs.new_version }}"
+          EXISTING=$(gh issue list --search "$TITLE" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "issue-number=$EXISTING" >> "$GITHUB_OUTPUT"
+            echo "Reusing existing issue #$EXISTING"
+          else
+            BODY="New flux-core release detected.
 
           **Current version:** ${{ needs.check-flux-core.outputs.current_version }}
           **New version:** ${{ needs.check-flux-core.outputs.new_version }}
@@ -340,17 +350,11 @@ jobs:
           - [ ] Verify patches are still needed for this version
           - [ ] Verify BuildRequires are still correct
           - [ ] Test build locally if possible
-          - [ ] Add changelog entry
-          EOF
-
-      - name: Create tracking issue
-        id: create-issue
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: "Update flux-core to ${{ needs.check-flux-core.outputs.new_version }}"
-          content-filepath: /tmp/issue-body.md
-          labels: enhancement,flux-core
-        continue-on-error: true
+          - [ ] Add changelog entry"
+            NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-core | grep -oP '\d+$')
+            echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
+            echo "Created issue #$NUM"
+          fi
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
@@ -389,10 +393,18 @@ jobs:
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-sched/releases/download/v${VERSION}/flux-sched-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-sched-${VERSION}.tar.gz) = ${SHA256}" > flux-sched/sources
 
-      - name: Write issue body
+      - name: Find or create tracking issue
+        id: create-issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cat > /tmp/issue-body.md << 'EOF'
-          New flux-sched release detected.
+          TITLE="Update flux-sched to ${{ needs.check-flux-sched.outputs.new_version }}"
+          EXISTING=$(gh issue list --search "$TITLE" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "issue-number=$EXISTING" >> "$GITHUB_OUTPUT"
+            echo "Reusing existing issue #$EXISTING"
+          else
+            BODY="New flux-sched release detected.
 
           **Current version:** ${{ needs.check-flux-sched.outputs.current_version }}
           **New version:** ${{ needs.check-flux-sched.outputs.new_version }}
@@ -403,17 +415,11 @@ jobs:
           - [ ] Verify patches are still needed for this version
           - [ ] Verify BuildRequires are still correct
           - [ ] Test build locally if possible
-          - [ ] Add changelog entry
-          EOF
-
-      - name: Create tracking issue
-        id: create-issue
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: "Update flux-sched to ${{ needs.check-flux-sched.outputs.new_version }}"
-          content-filepath: /tmp/issue-body.md
-          labels: enhancement,flux-sched
-        continue-on-error: true
+          - [ ] Add changelog entry"
+            NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-sched | grep -oP '\d+$')
+            echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
+            echo "Created issue #$NUM"
+          fi
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
@@ -452,10 +458,18 @@ jobs:
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-accounting/releases/download/v${VERSION}/flux-accounting-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-accounting-${VERSION}.tar.gz) = ${SHA256}" > flux-accounting/sources
 
-      - name: Write issue body
+      - name: Find or create tracking issue
+        id: create-issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cat > /tmp/issue-body.md << 'EOF'
-          New flux-accounting release detected.
+          TITLE="Update flux-accounting to ${{ needs.check-flux-accounting.outputs.new_version }}"
+          EXISTING=$(gh issue list --search "$TITLE" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "issue-number=$EXISTING" >> "$GITHUB_OUTPUT"
+            echo "Reusing existing issue #$EXISTING"
+          else
+            BODY="New flux-accounting release detected.
 
           **Current version:** ${{ needs.check-flux-accounting.outputs.current_version }}
           **New version:** ${{ needs.check-flux-accounting.outputs.new_version }}
@@ -466,17 +480,11 @@ jobs:
           - [ ] Verify patches are still needed for this version
           - [ ] Verify BuildRequires are still correct
           - [ ] Test build locally if possible
-          - [ ] Add changelog entry
-          EOF
-
-      - name: Create tracking issue
-        id: create-issue
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: "Update flux-accounting to ${{ needs.check-flux-accounting.outputs.new_version }}"
-          content-filepath: /tmp/issue-body.md
-          labels: enhancement,flux-accounting
-        continue-on-error: true
+          - [ ] Add changelog entry"
+            NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-accounting | grep -oP '\d+$')
+            echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
+            echo "Created issue #$NUM"
+          fi
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/reusable-mock-build.yml
+++ b/.github/workflows/reusable-mock-build.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download SRPMs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: srpms
           path: ./srpms
@@ -78,7 +78,7 @@ jobs:
           ls -la results-core/*.rpm 2>/dev/null | grep -v debuginfo >> test-summary.txt || true
 
       - name: Upload build results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: rpms-${{ inputs.mock-release }}

--- a/.github/workflows/reusable-mock-build.yml
+++ b/.github/workflows/reusable-mock-build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download SRPMs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: srpms
           path: ./srpms
@@ -78,7 +78,7 @@ jobs:
           ls -la results-core/*.rpm 2>/dev/null | grep -v debuginfo >> test-summary.txt || true
 
       - name: Upload build results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: rpms-${{ inputs.mock-release }}

--- a/.github/workflows/trigger-copr.yml
+++ b/.github/workflows/trigger-copr.yml
@@ -24,6 +24,13 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Validate COPR secrets
+        run: |
+          if [ -z "${{ secrets.COPR_LOGIN }}" ] || [ -z "${{ secrets.COPR_TOKEN }}" ]; then
+            echo "::error::COPR_LOGIN and COPR_TOKEN secrets must be configured. See https://copr.fedorainfracloud.org/api/"
+            exit 1
+          fi
+
       - name: Install copr-cli
         run: pip install copr-cli
 
@@ -41,22 +48,29 @@ jobs:
       - name: Detect changed packages
         id: detect
         run: |
+          ALL_PKGS="flux-security flux-core flux-sched flux-accounting"
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             INPUT="${{ github.event.inputs.packages }}"
             if [ "$INPUT" = "all" ] || [ -z "$INPUT" ]; then
-              echo "packages=flux-security flux-core flux-sched flux-accounting" >> "$GITHUB_OUTPUT"
+              PKGS="$ALL_PKGS"
             else
-              echo "packages=$INPUT" >> "$GITHUB_OUTPUT"
+              PKGS="$INPUT"
             fi
           else
-            CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'flux-*/' '.copr/' | \
-              grep -oP '^flux-[^/]+' | sort -u | tr '\n' ' ')
-            if git diff --name-only HEAD~1 HEAD -- '.copr/' | grep -q .; then
-              CHANGED="flux-security flux-core flux-sched flux-accounting"
+            if ! git rev-parse HEAD~1 >/dev/null 2>&1; then
+              echo "No parent commit available; rebuilding all packages"
+              PKGS="$ALL_PKGS"
+            elif git diff --name-only HEAD~1 HEAD -- '.copr/' | grep -q .; then
+              PKGS="$ALL_PKGS"
+            else
+              PKGS=$(git diff --name-only HEAD~1 HEAD -- 'flux-*/' | \
+                grep -oP '^flux-[^/]+' | sort -u | tr '\n' ' ')
             fi
-            echo "packages=$CHANGED" >> "$GITHUB_OUTPUT"
           fi
-          echo "Will trigger builds for: $(cat "$GITHUB_OUTPUT" | grep packages | cut -d= -f2)"
+
+          echo "packages=$PKGS" >> "$GITHUB_OUTPUT"
+          echo "Will trigger builds for: $PKGS"
 
       - name: Trigger COPR builds
         if: steps.detect.outputs.packages != ''

--- a/.github/workflows/trigger-copr.yml
+++ b/.github/workflows/trigger-copr.yml
@@ -20,7 +20,7 @@ jobs:
     name: Trigger COPR builds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 2
 

--- a/.github/workflows/trigger-copr.yml
+++ b/.github/workflows/trigger-copr.yml
@@ -1,0 +1,77 @@
+name: Trigger COPR Builds
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'flux-*/*.spec'
+      - 'flux-*/sources'
+      - 'flux-*/*.patch'
+      - '.copr/**'
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: 'Space-separated list of packages to rebuild (e.g. "flux-core flux-sched"), or "all"'
+        required: false
+        default: 'all'
+
+jobs:
+  trigger:
+    name: Trigger COPR builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Install copr-cli
+        run: pip install copr-cli
+
+      - name: Configure copr-cli
+        run: |
+          mkdir -p ~/.config
+          cat > ~/.config/copr <<EOF
+          [copr-cli]
+          login = ${{ secrets.COPR_LOGIN }}
+          username = kushgupta
+          token = ${{ secrets.COPR_TOKEN }}
+          copr_url = https://copr.fedorainfracloud.org
+          EOF
+
+      - name: Detect changed packages
+        id: detect
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            INPUT="${{ github.event.inputs.packages }}"
+            if [ "$INPUT" = "all" ] || [ -z "$INPUT" ]; then
+              echo "packages=flux-security flux-core flux-sched flux-accounting" >> "$GITHUB_OUTPUT"
+            else
+              echo "packages=$INPUT" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'flux-*/' '.copr/' | \
+              grep -oP '^flux-[^/]+' | sort -u | tr '\n' ' ')
+            if git diff --name-only HEAD~1 HEAD -- '.copr/' | grep -q .; then
+              CHANGED="flux-security flux-core flux-sched flux-accounting"
+            fi
+            echo "packages=$CHANGED" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Will trigger builds for: $(cat "$GITHUB_OUTPUT" | grep packages | cut -d= -f2)"
+
+      - name: Trigger COPR builds
+        if: steps.detect.outputs.packages != ''
+        run: |
+          FAILED=0
+          for pkg in ${{ steps.detect.outputs.packages }}; do
+            echo "::group::Triggering $pkg"
+            if copr-cli build-package --name "$pkg" "kushgupta/$pkg"; then
+              echo "Triggered $pkg build successfully"
+            else
+              echo "::warning::Failed to trigger $pkg build"
+              FAILED=1
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::warning::Some COPR builds failed to trigger. Check warnings above."
+          fi

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Heavily assisted through Cursor IDE with Claude Opus, but all code is reviewed b
 
 ## Installation
 
-Available for **Fedora** 41, 42, 43, Rawhide and **EPEL** 9, 10 via COPR. Packages must be installed in dependency order:
+Available for **Fedora** 42, 43, Rawhide and **EPEL** 9, 10 via COPR. Packages must be installed in dependency order:
 
 ```
 flux-security → flux-core → flux-sched
@@ -66,7 +66,7 @@ mock -r fedora-41-x86_64 --rebuild ~/rpmbuild/SRPMS/flux-accounting-*.src.rpm
 ## CI/CD
 
 **Build targets:**
-- **Fedora**: 41, 42, Rawhide
+- **Fedora**: 42, 43, Rawhide
 - **EPEL**: 9, 10 (CentOS Stream)
 
 **Automation:**

--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -1,5 +1,5 @@
 Name:    flux-accounting
-Version: 0.55.0
+Version: 0.56.0
 Release: 1%{?dist}
 Summary: Bank/Accounting Interface for the Flux Resource Manager
 License: LGPL-3.0-only
@@ -134,5 +134,9 @@ find %{buildroot}%{_libexecdir}/flux/cmd -name '*.py' -exec chmod 755 {} \;
 %{_mandir}/man1/*.1*
 
 %changelog
+* Wed Mar 11 2026 Kush Gupta <kugupta@redhat.com> - 0.56.0-1
+- Update to v0.56.0
+- New clear-usage command, decay factor fix, minor plugin improvements
+
 * Sun Jan 11 2026 Kushal Gupta <kugupta@redhat.com> - 0.55.0-1
 - Initial Fedora package based on upstream v0.55.0

--- a/flux-accounting/sources
+++ b/flux-accounting/sources
@@ -1,1 +1,1 @@
-SHA256 (flux-accounting-0.55.0.tar.gz) = 06c57d6a0c21be6c1c330fd934ab8324740e13a8bfb22f64fb701e6b14d11892
+SHA256 (flux-accounting-0.56.0.tar.gz) = c9e7dabd32215d00d67cda873425f3ea0f820468351df7ba3e2072e40d80d4e0

--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -1,5 +1,5 @@
 Name:    flux-core
-Version: 0.82.0
+Version: 0.83.1
 Release: 1%{?dist}
 Summary: Flux Resource Manager Framework
 License: LGPL-3.0-only
@@ -277,6 +277,10 @@ fi
 %{_mandir}/man3/*.3*
 
 %changelog
+* Wed Mar 11 2026 Kush Gupta <kugupta@redhat.com> - 0.83.1-1
+- Update to v0.83.1
+- NO_COLOR support, Python userid/rolemask getters, module loader helpers
+
 * Wed Feb 11 2026 Kush Gupta <kugupta@redhat.com> - 0.82.0-1
 - Update to v0.82.0
 - Drop const-correctness patch (merged upstream)

--- a/flux-core/sources
+++ b/flux-core/sources
@@ -1,1 +1,1 @@
-SHA256 (flux-core-0.82.0.tar.gz) = 26c4a324dd93a2cc395f158d5ddc44231dd256e9d9684b6fbc9838d5cd06ab65
+SHA256 (flux-core-0.83.1.tar.gz) = f46afb0f4cf79ca27314b2a5cb8fd90172ecee710f10a07ea6c008a12d806541

--- a/flux-sched/flux-sched.spec
+++ b/flux-sched/flux-sched.spec
@@ -164,7 +164,7 @@ find %{buildroot}%{_libexecdir}/flux/cmd -name '*.py' -exec chmod 755 {} \;
 * Thu Jan 15 2026 Kush Gupta <kush-gupt@users.noreply.github.com> - 0.48.0-2
 - Add patch to work around GCC 15 internal compiler error in scope_guard.hpp
 
-* Tue Jan 7 2026 Kush Gupta <kush-gupt@users.noreply.github.com> - 0.48.0-1
+* Wed Jan 7 2026 Kush Gupta <kush-gupt@users.noreply.github.com> - 0.48.0-1
 - Update to flux-sched v0.48.0
 - Add gcc-toolset-13 for EL9 builds (requires GCC 12+)
 - Adapt spec for Fedora packaging


### PR DESCRIPTION
## Summary

- **flux-core** 0.81.0 -> **0.83.1** (via 0.82.0): NO_COLOR support, Python userid/rolemask getters, module loader helpers, const-correctness patch dropped (merged upstream)
- **flux-sched** 0.48.0 -> **0.49.0**: CMake install LIBDIR fix for Rawhide (CMake 4.0+)
- **flux-accounting** 0.55.0 -> **0.56.0**: new `clear-usage` command, decay factor fix, plugin improvements
- **flux-security** stays at 0.14.0 (already latest)
- **CI workflow**: simplified `check-updates.yml` (auto-close tracking issues, simpler version bump logic)
- **COPR auto-trigger**: new `trigger-copr.yml` workflow that auto-kicks COPR builds on push to main when package files change (requires `COPR_LOGIN` and `COPR_TOKEN` repo secrets from https://copr.fedorainfracloud.org/api/)

## Supersedes

- PR #24 (flux-core 0.83.1)
- PR #15 (flux-core 0.83.0)
- PR #12 (flux-accounting 0.56.0)

## Setup required after merge

Add two repository secrets (Settings > Secrets and variables > Actions):
- `COPR_LOGIN` - from COPR API settings page
- `COPR_TOKEN` - from COPR API settings page

## Test plan

- [ ] CI builds all 4 packages across Fedora 41/42/43/Rawhide and CentOS Stream 9/10
- [ ] Smoke tests pass (flux start, job submission, KVS, scheduler, accounting)
- [ ] After merge, verify COPR trigger workflow fires

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Update Flux RPM packaging to latest upstream releases and streamline automated update and build workflows.

New Features:
- Add a GitHub Actions workflow to automatically trigger COPR builds when Flux packaging files or COPR configuration change.

Enhancements:
- Bump flux-core to 0.83.1 with upstream changes and drop the now-upstream const-correctness patch.
- Bump flux-sched to 0.49.0 and add a patch to fix CMake LIBDIR installation on Fedora Rawhide (CMake 4.0+).
- Bump flux-accounting to 0.56.0 with new upstream features and fixes.
- Simplify the check-updates workflow to edit spec/sources in-place, create tracking issues, and auto-close them from the generated PRs.
- Set explicit GitHub Actions permissions for the update workflow to allow creating and managing PRs and issues.