### PR TITLE
Disable LTO and strict-aliasing optimizations

### DIFF
--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -1,6 +1,6 @@
 Name:    flux-core
 Version: 0.83.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Flux Resource Manager Framework
 License: LGPL-3.0-only
 URL:     https://github.com/flux-framework/flux-core
@@ -9,10 +9,10 @@ Source0: %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 # Redhat only provides /usr/bin/false, but tests look for /bin/false
 %global __requires_exclude /bin/false
 
-# Disable strict-aliasing errors - upstream uses bundled libev which has
+# Disable strict-aliasing optimizations - upstream uses bundled libev which has
 # known strict-aliasing violations. Upstream already uses -Wno-strict-aliasing
-# in their build but Fedora's optflags may override this with -Werror variants.
-%global optflags %{optflags} -Wno-error=strict-aliasing
+# in their build but Fedora's optflags adds -O2 which enables -fstrict-aliasing.
+%global build_cflags %{build_cflags} -fno-strict-aliasing
 
 # Exclude flux Python subcommands from shebang mangling - these files are run
 # through the `flux python` wrapper and don't have shebangs by design. Without
@@ -277,6 +277,9 @@ fi
 %{_mandir}/man3/*.3*
 
 %changelog
+* Fri Mar 13 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.83.1-2
+- Disable strict-aliasing optimizations
+
 * Wed Mar 11 2026 Kush Gupta <kugupta@redhat.com> - 0.83.1-1
 - Update to v0.83.1
 - NO_COLOR support, Python userid/rolemask getters, module loader helpers

--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -9,6 +9,9 @@ Source0: %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 # Redhat only provides /usr/bin/false, but tests look for /bin/false
 %global __requires_exclude /bin/false
 
+# LTO causes a bunch of tests to fail so it should not be used
+%global _lto_cflags %{nil}
+
 # Disable strict-aliasing optimizations - upstream uses bundled libev which has
 # known strict-aliasing violations. Upstream already uses -Wno-strict-aliasing
 # in their build but Fedora's optflags adds -O2 which enables -fstrict-aliasing.
@@ -278,7 +281,7 @@ fi
 
 %changelog
 * Fri Mar 13 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.83.1-2
-- Disable strict-aliasing optimizations
+- Disable LTO and strict-aliasing optimizations
 
 * Wed Mar 11 2026 Kush Gupta <kugupta@redhat.com> - 0.83.1-1
 - Update to v0.83.1


### PR DESCRIPTION
The current strategy of setting
```
%global optflags %{optflags} -Wno-error=strict-aliasing
```
simply suppresses the errors and allows the warnings to be ignored when building, but if there are actual known strict-aliasing violations in `libev` then these optimizations should truly be disabled (you are not running the full test suite when you build, but in my testing there are many failures if these optimizations are used). Since this is only needed for the `CFLAGS` I have used the slightly more scoped `build_cflags` macro instead of the general `optflags`, i.e.:
```
%global build_cflags %{build_cflags} -fno-strict-aliasing
```
but there should be essentially no difference, since I think only C code is being compiled across the project.

Separately, in my testing I have encountered many failing tests if I do not disable LTO, so I have made a separate commit to also effect that change:
```
%global _lto_cflags %{nil}
```

## Summary by Sourcery

Adjust RPM packaging flags to avoid problematic compiler optimizations that break tests and rely on undefined strict-aliasing behavior.

Build:
- Disable LTO during RPM builds via _lto_cflags to prevent test failures.
- Replace suppression of strict-aliasing errors with explicit disabling of strict-aliasing optimizations in build CFLAGS.
- Bump RPM release from 1 to 2 for flux-core 0.83.1 to reflect packaging changes.