### PR TITLE
Requirements cleanup

### DIFF
--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -15,17 +15,19 @@ Patch0:  py-compile-python312.patch
 # this, brp-mangle-shebangs strips the executable bit we set, breaking `flux account`.
 %global __brp_mangle_shebangs_exclude_from ^%{_libexecdir}/flux/
 
+%global flux_core_minver 0.81.0
+
 BuildRequires: pkgconfig(jansson) >= 2.10
-BuildRequires: pkgconfig(sqlite3)
+BuildRequires: pkgconfig(sqlite3) >= 3.6.0
 BuildRequires: python3
 BuildRequires: pkgconfig(systemd)
-BuildRequires: python3-devel
+BuildRequires: python3-devel >= 3.9
 BuildRequires: python3-cffi
 BuildRequires: python3-pyyaml
-BuildRequires: python3-sphinx
+BuildRequires: python3-sphinx >= 1.6.7
 BuildRequires: python3-sphinx_rtd_theme
-BuildRequires: python3-docutils
-BuildRequires: pkgconfig(flux-core)
+BuildRequires: python3-docutils >= 0.11.0
+BuildRequires: pkgconfig(flux-core) >= %{flux_core_minver}
 
 BuildRequires: autoconf
 BuildRequires: automake
@@ -40,7 +42,7 @@ BuildRequires: systemd-rpm-macros
 # Required for en_US.UTF-8 locale during documentation build
 BuildRequires: glibc-langpack-en
 
-Requires: flux-core
+Requires: flux-core >= %{flux_core_minver}
 Requires: sqlite >= 3.6.0
 Requires: python3
 Requires: python3-cffi

--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -21,8 +21,6 @@ BuildRequires: pkgconfig(jansson) >= 2.10
 BuildRequires: pkgconfig(sqlite3) >= 3.6.0
 BuildRequires: pkgconfig(systemd)
 BuildRequires: python3-devel >= 3.9
-BuildRequires: python3-cffi
-BuildRequires: python3-pyyaml
 BuildRequires: python3-sphinx >= 1.6.7
 BuildRequires: python3-sphinx_rtd_theme
 BuildRequires: python3-docutils >= 0.11.0

--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -1,6 +1,6 @@
 Name:    flux-accounting
 Version: 0.56.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Bank/Accounting Interface for the Flux Resource Manager
 License: LGPL-3.0-only
 URL:     https://github.com/flux-framework/flux-accounting
@@ -98,8 +98,8 @@ find %{buildroot}%{_libexecdir}/flux/cmd -name '*.py' -exec chmod 755 {} \;
 %systemd_postun_with_restart flux-accounting.service
 
 %files
-%license DISCLAIMER.LLNS
-%doc README.md NEWS
+%license LICENSE
+%doc README.md NEWS.md
 
 # Python fluxacct package (uses sitearch due to native extensions)
 %{python3_sitearch}/fluxacct
@@ -129,6 +129,10 @@ find %{buildroot}%{_libexecdir}/flux/cmd -name '*.py' -exec chmod 755 {} \;
 %{_mandir}/man1/*.1*
 
 %changelog
+* Fri Mar 13 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.56.0-2
+- Clean up requirements and dependency versions
+- Package new changelog (NEWS.md) and LICENSE files
+
 * Wed Mar 11 2026 Kush Gupta <kugupta@redhat.com> - 0.56.0-1
 - Update to v0.56.0
 - New clear-usage command, decay factor fix, minor plugin improvements

--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -19,7 +19,6 @@ Patch0:  py-compile-python312.patch
 
 BuildRequires: pkgconfig(jansson) >= 2.10
 BuildRequires: pkgconfig(sqlite3) >= 3.6.0
-BuildRequires: python3
 BuildRequires: pkgconfig(systemd)
 BuildRequires: python3-devel >= 3.9
 BuildRequires: python3-cffi
@@ -44,7 +43,6 @@ BuildRequires: glibc-langpack-en
 
 Requires: flux-core >= %{flux_core_minver}
 Requires: sqlite >= 3.6.0
-Requires: python3
 Requires: python3-cffi
 Requires: python3-pyyaml
 

--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -40,9 +40,6 @@ BuildRequires: systemd-rpm-macros
 BuildRequires: glibc-langpack-en
 
 Requires: flux-core >= %{flux_core_minver}
-Requires: sqlite >= 3.6.0
-Requires: python3-cffi
-Requires: python3-pyyaml
 
 %description
 Flux Framework is a suite of projects, tools and libraries which may

--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -18,14 +18,14 @@ Patch0:  py-compile-python312.patch
 BuildRequires: pkgconfig(jansson) >= 2.10
 BuildRequires: pkgconfig(sqlite3)
 BuildRequires: python3
+BuildRequires: pkgconfig(systemd)
 BuildRequires: python3-devel
 BuildRequires: python3-cffi
 BuildRequires: python3-pyyaml
 BuildRequires: python3-sphinx
 BuildRequires: python3-sphinx_rtd_theme
 BuildRequires: python3-docutils
-BuildRequires: flux-core
-BuildRequires: flux-core-devel
+BuildRequires: pkgconfig(flux-core)
 
 BuildRequires: autoconf
 BuildRequires: automake

--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -62,10 +62,7 @@ BuildRequires: file
 BuildRequires: procps-ng
 
 # rely on autoreq for most dependencies
-Requires: lua >= 5.1
 Requires: lua-posix
-Requires: sqlite >= 3.6.0
-Requires: ncurses
 Requires: python3-cffi >= %{cffi_minver}
 Requires: python3-pyyaml >= %{pyyaml_minver}
 Requires: python3-ply >= %{ply_minver}

--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -22,11 +22,15 @@ Source0: %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 # this, brp-mangle-shebangs strips the executable bit we set, breaking `flux modprobe`.
 %global __brp_mangle_shebangs_exclude_from ^%{_libexecdir}/flux/
 
+%global cffi_minver        1.1
+%global ply_minver         3.9
+%global pyyaml_minver      3.10
 
 BuildRequires: pkgconfig(flux-security) >= 0.14
-BuildRequires: pkgconfig(libzmq) >= 4.1.4
-BuildRequires: pkgconfig(jansson) >= 2.6
-BuildRequires: pkgconfig(hwloc) >= 2.1
+
+BuildRequires: pkgconfig(libzmq) >= 4.0.4
+BuildRequires: pkgconfig(jansson) >= 2.9
+BuildRequires: pkgconfig(hwloc) >= 1.11.1
 BuildRequires: pkgconfig(sqlite3) >= 3.6.0
 BuildRequires: pkgconfig(bash-completion)
 BuildRequires: pkgconfig(liblz4)
@@ -34,7 +38,7 @@ BuildRequires: pkgconfig(uuid)
 BuildRequires: pkgconfig(ncurses)
 BuildRequires: pkgconfig(libarchive)
 BuildRequires: pkgconfig(systemd)
-BuildRequires: lua-devel >= 5.1
+BuildRequires: (lua-devel >= 5.1 and lua-devel < 5.5)
 BuildRequires: munge-devel
 BuildRequires: lua-posix
 
@@ -64,23 +68,23 @@ BuildRequires: krb5-devel
 
 # rely on autoreq for most dependencies
 Requires: lua >= 5.1
-Requires: lua-posix >= 5.1
+Requires: lua-posix
 Requires: sqlite >= 3.6.0
 Requires: ncurses
 Requires: python3
-Requires: python3-cffi
-Requires: python3-pyyaml
-Requires: python3-ply
+Requires: python3-cffi >= %{cffi_minver}
+Requires: python3-pyyaml >= %{pyyaml_minver}
+Requires: python3-ply >= %{ply_minver}
 
 BuildRequires: python3
-BuildRequires: python3-devel
-BuildRequires: python3-cffi
-BuildRequires: python3-pyyaml
-BuildRequires: python3-ply
+BuildRequires: python3-devel >= 3.6
+BuildRequires: python3-cffi >= %{cffi_minver}
+BuildRequires: python3-pyyaml >= %{pyyaml_minver}
+BuildRequires: python3-ply >= %{ply_minver}
 BuildRequires: python3-setuptools
-BuildRequires: python3-sphinx
+BuildRequires: python3-sphinx >= 1.6.7
 BuildRequires: python3-sphinx_rtd_theme
-BuildRequires: python3-docutils
+BuildRequires: python3-docutils >= 0.11.0
 
 BuildRequires: autoconf
 BuildRequires: automake

--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -22,21 +22,21 @@ Source0: %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 # this, brp-mangle-shebangs strips the executable bit we set, breaking `flux modprobe`.
 %global __brp_mangle_shebangs_exclude_from ^%{_libexecdir}/flux/
 
-BuildRequires: flux-security-devel >= 0.14
 
+BuildRequires: pkgconfig(flux-security) >= 0.14
 BuildRequires: pkgconfig(libzmq) >= 4.1.4
 BuildRequires: pkgconfig(jansson) >= 2.6
 BuildRequires: pkgconfig(hwloc) >= 2.1
 BuildRequires: pkgconfig(sqlite3) >= 3.6.0
 BuildRequires: pkgconfig(bash-completion)
+BuildRequires: pkgconfig(liblz4)
+BuildRequires: pkgconfig(uuid)
+BuildRequires: pkgconfig(ncurses)
+BuildRequires: pkgconfig(libarchive)
+BuildRequires: pkgconfig(systemd)
 BuildRequires: lua-devel >= 5.1
-BuildRequires: lz4-devel
 BuildRequires: munge-devel
 BuildRequires: lua-posix
-BuildRequires: libuuid-devel
-BuildRequires: ncurses-devel
-BuildRequires: libarchive-devel
-BuildRequires: systemd-devel
 
 # for _tmpfilesdir
 BuildRequires: systemd-rpm-macros

--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -71,12 +71,10 @@ Requires: lua >= 5.1
 Requires: lua-posix
 Requires: sqlite >= 3.6.0
 Requires: ncurses
-Requires: python3
 Requires: python3-cffi >= %{cffi_minver}
 Requires: python3-pyyaml >= %{pyyaml_minver}
 Requires: python3-ply >= %{ply_minver}
 
-BuildRequires: python3
 BuildRequires: python3-devel >= 3.6
 BuildRequires: python3-cffi >= %{cffi_minver}
 BuildRequires: python3-pyyaml >= %{pyyaml_minver}

--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -1,6 +1,6 @@
 Name:    flux-core
 Version: 0.83.1
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Flux Resource Manager Framework
 License: LGPL-3.0-only
 URL:     https://github.com/flux-framework/flux-core
@@ -274,6 +274,9 @@ fi
 %{_mandir}/man3/*.3*
 
 %changelog
+* Fri Mar 13 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.83.1-3
+- Clean up requirements and dependency versions
+
 * Fri Mar 13 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.83.1-2
 - Disable LTO and strict-aliasing optimizations
 

--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -61,11 +61,6 @@ BuildRequires: which
 BuildRequires: file
 BuildRequires: procps-ng
 
-# libtool CCLD of libflux-core.la adds -lsodium -lpgm -lgssapi_krb5
-BuildRequires: libsodium-devel >= 0.4.5
-BuildRequires: openpgm-devel
-BuildRequires: krb5-devel
-
 # rely on autoreq for most dependencies
 Requires: lua >= 5.1
 Requires: lua-posix

--- a/flux-sched/flux-sched.spec
+++ b/flux-sched/flux-sched.spec
@@ -1,6 +1,6 @@
 Name:    flux-sched
 Version: 0.49.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Job Scheduling Facility for Flux Resource Manager Framework
 License: LGPL-3.0-only
 URL:     https://github.com/flux-framework/flux-sched
@@ -150,6 +150,9 @@ find %{buildroot}%{_libexecdir}/flux/cmd -name '*.py' -exec chmod 755 {} \;
 %{_mandir}/man5/*
 
 %changelog
+* Fri Mar 13 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.49.0-2
+- Clean up requirements and dependency versions
+
 * Wed Feb 11 2026 Kush Gupta <kugupta@redhat.com> - 0.49.0-1
 - Update to v0.49.0
 - Add patch to fix CMake install LIBDIR on Fedora Rawhide (CMake 4.0+)

--- a/flux-sched/flux-sched.spec
+++ b/flux-sched/flux-sched.spec
@@ -27,6 +27,7 @@ Patch1:  cmake-install-libdir-fix.patch
 ExcludeArch: ppc64le
 
 %global flux_core_minver 0.75.0
+%global boost_minver     1.66
 %global pyyaml_minver    3.10
 
 BuildRequires: pkgconfig(flux-core) >= %{flux_core_minver}
@@ -44,9 +45,8 @@ BuildRequires: pkgconfig(yaml-cpp) >= 0.5.1
 BuildRequires: pkgconfig(libedit) >= 3.0
 BuildRequires: pkgconfig(uuid)
 
-BuildRequires: boost >= 1.66.0
-BuildRequires: boost-devel
-BuildRequires: boost-graph
+BuildRequires: boost-devel >= %{boost_minver}
+BuildRequires: boost-graph >= %{boost_minver}
 
 BuildRequires: python3-pyyaml >= %{pyyaml_minver}
 BuildRequires: python3-sphinx

--- a/flux-sched/flux-sched.spec
+++ b/flux-sched/flux-sched.spec
@@ -48,6 +48,7 @@ BuildRequires: pkgconfig(uuid)
 BuildRequires: boost-devel >= %{boost_minver}
 BuildRequires: boost-graph >= %{boost_minver}
 
+BuildRequires: python3-devel >= 3.6
 BuildRequires: python3-pyyaml >= %{pyyaml_minver}
 BuildRequires: python3-sphinx
 BuildRequires: python3-sphinx_rtd_theme
@@ -56,12 +57,6 @@ BuildRequires: python3-jsonschema >= 2.3.0
 
 # Should be pulled in by flux-core, but isn't
 BuildRequires: python3-cffi
-
-# Should be pulled in by flux-core
-BuildRequires: python3 >= 3.6
-
-# Required only by configure?
-BuildRequires: python3-devel
 
 # Required for 'make check'
 BuildRequires: aspell

--- a/flux-sched/flux-sched.spec
+++ b/flux-sched/flux-sched.spec
@@ -37,10 +37,8 @@ BuildRequires: gcc-c++
 %if 0%{?rhel} == 9
 BuildRequires: gcc-toolset-13-gcc-c++
 %endif
-BuildRequires: pkgconfig(libzmq) >= 4.1.4
 BuildRequires: pkgconfig(jansson) >= 2.10
 BuildRequires: pkgconfig(hwloc) >= 2
-BuildRequires: pkgconfig(libxml-2.0) >= 2.9
 BuildRequires: pkgconfig(yaml-cpp) >= 0.5.1
 BuildRequires: pkgconfig(libedit) >= 3.0
 BuildRequires: pkgconfig(uuid)
@@ -52,11 +50,7 @@ BuildRequires: python3-devel >= 3.6
 BuildRequires: python3-pyyaml >= %{pyyaml_minver}
 BuildRequires: python3-sphinx
 BuildRequires: python3-sphinx_rtd_theme
-BuildRequires: python3-docutils
 BuildRequires: python3-jsonschema >= 2.3.0
-
-# Should be pulled in by flux-core, but isn't
-BuildRequires: python3-cffi
 
 # Required for 'make check'
 BuildRequires: aspell

--- a/flux-sched/flux-sched.spec
+++ b/flux-sched/flux-sched.spec
@@ -26,30 +26,32 @@ Patch1:  cmake-install-libdir-fix.patch
 
 ExcludeArch: ppc64le
 
-BuildRequires: cmake
-BuildRequires: pkgconfig(flux-core) >= 0.75.0
+%global flux_core_minver 0.75.0
+
+BuildRequires: pkgconfig(flux-core) >= %{flux_core_minver}
+BuildRequires: cmake >= 3.18
 BuildRequires: gcc-c++
 # flux-sched requires GCC 12+ for C++20 features
 %if 0%{?rhel} == 9
 BuildRequires: gcc-toolset-13-gcc-c++
 %endif
 BuildRequires: pkgconfig(libzmq) >= 4.1.4
-BuildRequires: pkgconfig(jansson) >= 2.6
-BuildRequires: pkgconfig(hwloc) >= 2.1
+BuildRequires: pkgconfig(jansson) >= 2.10
+BuildRequires: pkgconfig(hwloc) >= 2
 BuildRequires: pkgconfig(libxml-2.0) >= 2.9
 BuildRequires: pkgconfig(yaml-cpp) >= 0.5.1
-BuildRequires: pkgconfig(libedit)
+BuildRequires: pkgconfig(libedit) >= 3.0
 BuildRequires: pkgconfig(uuid)
 
-BuildRequires: boost >= 1.53.0
+BuildRequires: boost >= 1.66.0
 BuildRequires: boost-devel
 BuildRequires: boost-graph
 
-BuildRequires: python3-pyyaml
+BuildRequires: python3-pyyaml >= 3.10
 BuildRequires: python3-sphinx
 BuildRequires: python3-sphinx_rtd_theme
 BuildRequires: python3-docutils
-BuildRequires: python3-jsonschema
+BuildRequires: python3-jsonschema >= 2.3.0
 
 # Should be pulled in by flux-core, but isn't
 BuildRequires: python3-cffi
@@ -76,7 +78,7 @@ BuildRequires: gdb
 # Required for en_US.UTF-8 locale during build
 BuildRequires: glibc-langpack-en
 
-Requires: flux-core >= 0.75.0
+Requires: flux-core >= %{flux_core_minver}
 
 %description
 flux-sched contains the Fluxion graph-based scheduler for the Flux

--- a/flux-sched/flux-sched.spec
+++ b/flux-sched/flux-sched.spec
@@ -26,8 +26,8 @@ Patch1:  cmake-install-libdir-fix.patch
 
 ExcludeArch: ppc64le
 
-BuildRequires: flux-core-devel >= 0.75.0
 BuildRequires: cmake
+BuildRequires: pkgconfig(flux-core) >= 0.75.0
 BuildRequires: gcc-c++
 # flux-sched requires GCC 12+ for C++20 features
 %if 0%{?rhel} == 9
@@ -37,9 +37,9 @@ BuildRequires: pkgconfig(libzmq) >= 4.1.4
 BuildRequires: pkgconfig(jansson) >= 2.6
 BuildRequires: pkgconfig(hwloc) >= 2.1
 BuildRequires: pkgconfig(libxml-2.0) >= 2.9
-BuildRequires: yaml-cpp-devel >= 0.5.1
-BuildRequires: libedit-devel
-BuildRequires: libuuid-devel
+BuildRequires: pkgconfig(yaml-cpp) >= 0.5.1
+BuildRequires: pkgconfig(libedit)
+BuildRequires: pkgconfig(uuid)
 
 BuildRequires: boost >= 1.53.0
 BuildRequires: boost-devel

--- a/flux-sched/flux-sched.spec
+++ b/flux-sched/flux-sched.spec
@@ -27,6 +27,7 @@ Patch1:  cmake-install-libdir-fix.patch
 ExcludeArch: ppc64le
 
 %global flux_core_minver 0.75.0
+%global pyyaml_minver    3.10
 
 BuildRequires: pkgconfig(flux-core) >= %{flux_core_minver}
 BuildRequires: cmake >= 3.18
@@ -47,7 +48,7 @@ BuildRequires: boost >= 1.66.0
 BuildRequires: boost-devel
 BuildRequires: boost-graph
 
-BuildRequires: python3-pyyaml >= 3.10
+BuildRequires: python3-pyyaml >= %{pyyaml_minver}
 BuildRequires: python3-sphinx
 BuildRequires: python3-sphinx_rtd_theme
 BuildRequires: python3-docutils
@@ -79,6 +80,7 @@ BuildRequires: gdb
 BuildRequires: glibc-langpack-en
 
 Requires: flux-core >= %{flux_core_minver}
+Requires: python3-pyyaml >= %{pyyaml_minver}
 
 %description
 flux-sched contains the Fluxion graph-based scheduler for the Flux

--- a/flux-security/flux-security.spec
+++ b/flux-security/flux-security.spec
@@ -13,13 +13,13 @@ Source0: %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 Patch0:  211.patch
 
 BuildRequires: pkgconfig(libsodium) >= 1.0.14
-BuildRequires: pkgconfig(jansson) >= 2.6
+BuildRequires: pkgconfig(jansson) >= 2.10
 BuildRequires: pkgconfig(munge)
 BuildRequires: pkgconfig(uuid)
 BuildRequires: pam-devel
-BuildRequires: python3-sphinx
+BuildRequires: python3-sphinx >= 1.6.7
 BuildRequires: python3-sphinx_rtd_theme
-BuildRequires: python3-docutils
+BuildRequires: python3-docutils >= 0.11.0
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: libtool

--- a/flux-security/flux-security.spec
+++ b/flux-security/flux-security.spec
@@ -17,6 +17,7 @@ BuildRequires: pkgconfig(jansson) >= 2.10
 BuildRequires: pkgconfig(munge)
 BuildRequires: pkgconfig(uuid)
 BuildRequires: pam-devel
+BuildRequires: python3-devel
 BuildRequires: python3-sphinx >= 1.6.7
 BuildRequires: python3-sphinx_rtd_theme
 BuildRequires: python3-docutils >= 0.11.0

--- a/flux-security/flux-security.spec
+++ b/flux-security/flux-security.spec
@@ -14,9 +14,9 @@ Patch0:  211.patch
 
 BuildRequires: pkgconfig(libsodium) >= 1.0.14
 BuildRequires: pkgconfig(jansson) >= 2.6
-BuildRequires: munge-devel
+BuildRequires: pkgconfig(munge)
+BuildRequires: pkgconfig(uuid)
 BuildRequires: pam-devel
-BuildRequires: libuuid-devel
 BuildRequires: python3-sphinx
 BuildRequires: python3-sphinx_rtd_theme
 BuildRequires: python3-docutils

--- a/flux-security/flux-security.spec
+++ b/flux-security/flux-security.spec
@@ -1,6 +1,6 @@
 Name:    flux-security
 Version: 0.14.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 
 Summary: Flux Framework Security Components
 License: LGPL-3.0-only
@@ -110,6 +110,9 @@ mkdir -p %{buildroot}%{_sysconfdir}/flux/imp/conf.d
 %{_mandir}/man3/*.3*
 
 %changelog
+* Fri Mar 13 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.14.0-3
+- Clean up requirements and dependency versions
+
 * Tue Jan  6 2026 Kush Gupta <kugupta@redhat.com> - 0.14.0-2
 - Add patch based on PR #211 to fix GCC 16 build failure on Fedora Rawhide
 - Includes fix for missing const in payload_decode_cpy (potentially incomplete in upstream PR)


### PR DESCRIPTION
This PR builds on top of #33 for `flux-core`, so that should be finalized and merged first.

This is basically an attempt to cleanup the requirements and dependency versions throughout. I've attempted to separate changes into sensible commits for review, but I'll try to give a brief summary here:

1. Make sure all BuildRequires that are found using `pkgconf` are marked accordingly: https://docs.fedoraproject.org/en-US/packaging-guidelines/PkgConfigBuildRequires/

2. Attempt to align required versions with what is actually checked for in the build systems. See some relevant discussion here: https://github.com/flux-framework/flux-core/issues/7295
  - I also note here that `flux-core` requires a Lua version >= 5.1 and < 5.5, but fedora rawhide only appears to provide 5.5, so it doesn't currently build there.

3. Add a runtime Requires for `python3-pyyaml` to `flux-sched`, but otherwise remove a number of unnecessary Requires that are found and automatically added by rpmbuild: https://docs.fedoraproject.org/en-US/packaging-guidelines/#_explicit_requires

4. Reduce `boost` dependency to only the `boost-graph` and `boost-devel` that are actually needed in `flux-sched`

5. Model Fedora Python packaging guidelines: https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_dependencies

6. Remove some out-of-date BuildRequires that I think are just artifacts from the TOSS spec files

## Summary by Sourcery

Clean up RPM packaging for Flux components by aligning dependency versions and types with upstream build requirements and Fedora guidelines, while disabling problematic compiler optimizations.

Bug Fixes:
- Disable LTO and strict-aliasing optimizations in flux-core to avoid test and strict-aliasing issues.

Enhancements:
- Convert direct devel library BuildRequires to pkgconfig-style dependencies and tighten minimum versions across flux-core, flux-sched, flux-accounting, and flux-security.
- Reduce and clarify Python runtime and build dependencies, including adding explicit python3-pyyaml runtime requirement for flux-sched and centralizing version macros.
- Remove redundant or automatically-generated Requires/BuildRequires and align Flux package interdependencies via pkgconfig and shared version macros.
- Update flux-accounting packaging to install the LICENSE and NEWS.md files instead of legacy documentation names.

Build:
- Bump release numbers and update changelog entries for all affected spec files to reflect dependency and packaging cleanups.

Documentation:
- Adjust packaged documentation for flux-accounting to include the new NEWS.md changelog and LICENSE file instead of the previous disclaimer and NEWS.