### PR TITLE
flux-accounting: align Python version requirement with other packages

### DIFF
--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -1,6 +1,6 @@
 Name:    flux-accounting
 Version: 0.56.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Bank/Accounting Interface for the Flux Resource Manager
 License: LGPL-3.0-only
 URL:     https://github.com/flux-framework/flux-accounting
@@ -20,7 +20,7 @@ Patch0:  py-compile-python312.patch
 BuildRequires: pkgconfig(jansson) >= 2.10
 BuildRequires: pkgconfig(sqlite3) >= 3.6.0
 BuildRequires: pkgconfig(systemd)
-BuildRequires: python3-devel >= 3.9
+BuildRequires: python3-devel >= 3.6
 BuildRequires: python3-sphinx >= 1.6.7
 BuildRequires: python3-sphinx_rtd_theme
 BuildRequires: python3-docutils >= 0.11.0
@@ -129,6 +129,9 @@ find %{buildroot}%{_libexecdir}/flux/cmd -name '*.py' -exec chmod 755 {} \;
 %{_mandir}/man1/*.1*
 
 %changelog
+* Fri Mar 13 2026 Kush Gupta <kugupta@redhat.com> - 0.56.0-3
+- Align Python version requirement (>= 3.6) with flux-core and flux-sched
+
 * Fri Mar 13 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.56.0-2
 - Clean up requirements and dependency versions
 - Package new changelog (NEWS.md) and LICENSE files


### PR DESCRIPTION
## Summary
- Changes flux-accounting's `BuildRequires: python3-devel >= 3.9` to `>= 3.6` to match flux-core and flux-sched
- The upstream flux-accounting `configure.ac` specifies no minimum Python version (inherits from flux-core via `FLUX_PYTHON_VERSION`), and the upstream LLNL SRPM uses unversioned `python3-devel` -- there is no upstream basis for requiring 3.9
- Bumps Release to 3 with corresponding changelog entry

## Verification
- Checked upstream `configure.ac` (both `master` and `v0.56.0` tags): uses `AM_PATH_PYTHON([$PYTHON_VERSION])` with no hardcoded minimum
- Extracted spec files from both upstream SRPMs (v0.51.0 and v0.16.0): neither specifies a version on `python3-devel`
- flux-core and flux-sched both use `python3-devel >= 3.6`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Relax the flux-accounting package's Python build dependency to match other Flux components and bump the RPM release.

Enhancements:
- Lower the Python build requirement for flux-accounting to python3-devel >= 3.6 to align with flux-core and flux-sched.

Build:
- Increment the RPM Release to 3 and add a corresponding changelog entry.