### PR TITLE
core/sched: bump jansson requirement to v2.11

### DIFF
--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -1,6 +1,6 @@
 Name:    flux-core
 Version: 0.83.1
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Flux Resource Manager Framework
 License: LGPL-3.0-only
 URL:     https://github.com/flux-framework/flux-core
@@ -29,7 +29,7 @@ Source0: %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 BuildRequires: pkgconfig(flux-security) >= 0.14
 
 BuildRequires: pkgconfig(libzmq) >= 4.0.4
-BuildRequires: pkgconfig(jansson) >= 2.9
+BuildRequires: pkgconfig(jansson) >= 2.11
 BuildRequires: pkgconfig(hwloc) >= 1.11.1
 BuildRequires: pkgconfig(sqlite3) >= 3.6.0
 BuildRequires: pkgconfig(bash-completion)
@@ -274,6 +274,9 @@ fi
 %{_mandir}/man3/*.3*
 
 %changelog
+* Wed Apr 22 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.83.1-4
+- Bump jansson requirement to v2.11
+
 * Fri Mar 13 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.83.1-3
 - Clean up requirements and dependency versions
 

--- a/flux-sched/flux-sched.spec
+++ b/flux-sched/flux-sched.spec
@@ -1,6 +1,6 @@
 Name:    flux-sched
 Version: 0.49.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Job Scheduling Facility for Flux Resource Manager Framework
 License: LGPL-3.0-only
 URL:     https://github.com/flux-framework/flux-sched
@@ -37,7 +37,7 @@ BuildRequires: gcc-c++
 %if 0%{?rhel} == 9
 BuildRequires: gcc-toolset-13-gcc-c++
 %endif
-BuildRequires: pkgconfig(jansson) >= 2.10
+BuildRequires: pkgconfig(jansson) >= 2.11
 BuildRequires: pkgconfig(hwloc) >= 2
 BuildRequires: pkgconfig(yaml-cpp) >= 0.5.1
 BuildRequires: pkgconfig(libedit) >= 3.0
@@ -150,6 +150,9 @@ find %{buildroot}%{_libexecdir}/flux/cmd -name '*.py' -exec chmod 755 {} \;
 %{_mandir}/man5/*
 
 %changelog
+* Wed Apr 22 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.49.0-3
+- Bump jansson requirement to v2.11
+
 * Fri Mar 13 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.49.0-2
 - Clean up requirements and dependency versions
 


### PR DESCRIPTION
Matching to new requirements from:
https://github.com/flux-framework/flux-core/pull/7554
https://github.com/flux-framework/flux-sched/pull/1455

## Summary by Sourcery

Raise the jansson library minimum version requirement to 2.11 across core and scheduler RPM spec files to align with updated project dependencies.

Build:
- Update flux-core.spec to require pkgconfig(jansson) >= 2.11 for builds.
- Update flux-sched.spec to require pkgconfig(jansson) >= 2.11 for builds.