### PR TITLE
Improve update CI

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -261,6 +261,12 @@ jobs:
           VERSION="${{ needs.check-flux-security.outputs.new_version }}"
           sed -i "s/^Version:.*/Version: ${VERSION}/" flux-security/flux-security.spec
           sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-security/flux-security.spec
+          sed -i "/^%changelog$/r"<(cat <<-EOF
+          * $(date +'%a %b %d %Y') Kush Gupta <kugupta@redhat.com> - ${VERSION}-1
+          - Update to v${VERSION}
+          
+          EOF
+          ) flux-security/flux-security.spec
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-security/releases/download/v${VERSION}/flux-security-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-security-${VERSION}.tar.gz) = ${SHA256}" > flux-security/sources
 
@@ -285,8 +291,7 @@ jobs:
           - [ ] Check release notes for spec file changes
           - [ ] Verify patches are still needed for this version
           - [ ] Verify BuildRequires are still correct
-          - [ ] Test build locally if possible
-          - [ ] Add changelog entry"
+          - [ ] Test build locally if possible"
             NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-security | grep -oP '\d+$')
             echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
             echo "Created issue #$NUM"
@@ -310,7 +315,6 @@ jobs:
             - [ ] Verify patches are still needed for this version
             - [ ] Verify BuildRequires are still correct
             - [ ] Test build locally if possible
-            - [ ] Add changelog entry
           branch: update-flux-security-${{ needs.check-flux-security.outputs.new_version }}
           delete-branch: true
 
@@ -327,6 +331,12 @@ jobs:
           VERSION="${{ needs.check-flux-core.outputs.new_version }}"
           sed -i "s/^Version:.*/Version: ${VERSION}/" flux-core/flux-core.spec
           sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-core/flux-core.spec
+          sed -i "/^%changelog$/r"<(cat <<-EOF
+          * $(date +'%a %b %d %Y') Kush Gupta <kugupta@redhat.com> - ${VERSION}-1
+          - Update to v${VERSION}
+          
+          EOF
+          ) flux-core/flux-core.spec
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-core/releases/download/v${VERSION}/flux-core-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-core-${VERSION}.tar.gz) = ${SHA256}" > flux-core/sources
 
@@ -351,8 +361,7 @@ jobs:
           - [ ] Check release notes for spec file changes
           - [ ] Verify patches are still needed for this version
           - [ ] Verify BuildRequires are still correct
-          - [ ] Test build locally if possible
-          - [ ] Add changelog entry"
+          - [ ] Test build locally if possible"
             NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-core | grep -oP '\d+$')
             echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
             echo "Created issue #$NUM"
@@ -376,7 +385,6 @@ jobs:
             - [ ] Verify patches are still needed for this version
             - [ ] Verify BuildRequires are still correct
             - [ ] Test build locally if possible
-            - [ ] Add changelog entry
           branch: update-flux-core-${{ needs.check-flux-core.outputs.new_version }}
           delete-branch: true
 
@@ -393,6 +401,12 @@ jobs:
           VERSION="${{ needs.check-flux-sched.outputs.new_version }}"
           sed -i "s/^Version:.*/Version: ${VERSION}/" flux-sched/flux-sched.spec
           sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-sched/flux-sched.spec
+          sed -i "/^%changelog$/r"<(cat <<-EOF
+          * $(date +'%a %b %d %Y') Kush Gupta <kugupta@redhat.com> - ${VERSION}-1
+          - Update to v${VERSION}
+          
+          EOF
+          ) flux-sched/flux-sched.spec
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-sched/releases/download/v${VERSION}/flux-sched-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-sched-${VERSION}.tar.gz) = ${SHA256}" > flux-sched/sources
 
@@ -417,8 +431,7 @@ jobs:
           - [ ] Check release notes for spec file changes
           - [ ] Verify patches are still needed for this version
           - [ ] Verify BuildRequires are still correct
-          - [ ] Test build locally if possible
-          - [ ] Add changelog entry"
+          - [ ] Test build locally if possible"
             NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-sched | grep -oP '\d+$')
             echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
             echo "Created issue #$NUM"
@@ -442,7 +455,6 @@ jobs:
             - [ ] Verify patches are still needed for this version
             - [ ] Verify BuildRequires are still correct
             - [ ] Test build locally if possible
-            - [ ] Add changelog entry
           branch: update-flux-sched-${{ needs.check-flux-sched.outputs.new_version }}
           delete-branch: true
 
@@ -459,6 +471,12 @@ jobs:
           VERSION="${{ needs.check-flux-accounting.outputs.new_version }}"
           sed -i "s/^Version:.*/Version: ${VERSION}/" flux-accounting/flux-accounting.spec
           sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-accounting/flux-accounting.spec
+          sed -i "/^%changelog$/r"<(cat <<-EOF
+          * $(date +'%a %b %d %Y') Kush Gupta <kugupta@redhat.com> - ${VERSION}-1
+          - Update to v${VERSION}
+          
+          EOF
+          ) flux-accounting/flux-accounting.spec
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-accounting/releases/download/v${VERSION}/flux-accounting-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-accounting-${VERSION}.tar.gz) = ${SHA256}" > flux-accounting/sources
 
@@ -483,8 +501,7 @@ jobs:
           - [ ] Check release notes for spec file changes
           - [ ] Verify patches are still needed for this version
           - [ ] Verify BuildRequires are still correct
-          - [ ] Test build locally if possible
-          - [ ] Add changelog entry"
+          - [ ] Test build locally if possible"
             NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-accounting | grep -oP '\d+$')
             echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
             echo "Created issue #$NUM"
@@ -508,6 +525,5 @@ jobs:
             - [ ] Verify patches are still needed for this version
             - [ ] Verify BuildRequires are still correct
             - [ ] Test build locally if possible
-            - [ ] Add changelog entry
           branch: update-flux-accounting-${{ needs.check-flux-accounting.outputs.new_version }}
           delete-branch: true

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -260,6 +260,7 @@ jobs:
         run: |
           VERSION="${{ needs.check-flux-security.outputs.new_version }}"
           sed -i "s/^Version:.*/Version: ${VERSION}/" flux-security/flux-security.spec
+          sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-security/flux-security.spec
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-security/releases/download/v${VERSION}/flux-security-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-security-${VERSION}.tar.gz) = ${SHA256}" > flux-security/sources
 
@@ -325,6 +326,7 @@ jobs:
         run: |
           VERSION="${{ needs.check-flux-core.outputs.new_version }}"
           sed -i "s/^Version:.*/Version: ${VERSION}/" flux-core/flux-core.spec
+          sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-core/flux-core.spec
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-core/releases/download/v${VERSION}/flux-core-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-core-${VERSION}.tar.gz) = ${SHA256}" > flux-core/sources
 
@@ -390,6 +392,7 @@ jobs:
         run: |
           VERSION="${{ needs.check-flux-sched.outputs.new_version }}"
           sed -i "s/^Version:.*/Version: ${VERSION}/" flux-sched/flux-sched.spec
+          sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-sched/flux-sched.spec
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-sched/releases/download/v${VERSION}/flux-sched-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-sched-${VERSION}.tar.gz) = ${SHA256}" > flux-sched/sources
 
@@ -455,6 +458,7 @@ jobs:
         run: |
           VERSION="${{ needs.check-flux-accounting.outputs.new_version }}"
           sed -i "s/^Version:.*/Version: ${VERSION}/" flux-accounting/flux-accounting.spec
+          sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-accounting/flux-accounting.spec
           SHA256=$(curl -sL "https://github.com/flux-framework/flux-accounting/releases/download/v${VERSION}/flux-accounting-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
           echo "SHA256 (flux-accounting-${VERSION}.tar.gz) = ${SHA256}" > flux-accounting/sources
 

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -19,25 +19,31 @@ jobs:
   # ============================================================
   # Check for version updates (runs in parallel)
   # ============================================================
-  check-flux-security:
-    name: Check flux-security updates
+  check-all:
+    name: Check ${{ matrix.package }} updates
     runs-on: ubuntu-latest
-    outputs:
-      new_version: ${{ steps.check.outputs.new_version }}
-      current_version: ${{ steps.check.outputs.current_version }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: flux-security
+          - package: flux-core
+          - package: flux-sched
+          - package: flux-accounting
     steps:
       - uses: actions/checkout@v5
 
       - name: Get current version
         id: current
         run: |
-          version=$(grep '^Version:' flux-security/flux-security.spec | awk '{print $2}')
+          version=$(grep '^Version:' ${{ matrix.package }}/${{ matrix.package }}.spec | awk '{print $2}')
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Get latest release
         id: latest
         run: |
-          response=$(curl -sf "https://api.github.com/repos/flux-framework/flux-security/releases?per_page=1") || {
+          response=$(curl -sf "https://api.github.com/repos/flux-framework/${{ matrix.package }}/releases?per_page=1") || {
             echo "Failed to fetch releases from GitHub API"
             echo "version=" >> $GITHUB_OUTPUT
             exit 0
@@ -52,11 +58,10 @@ jobs:
           fi
 
       - name: Check for update
-        id: check
+        id: new
         run: |
           current="${{ steps.current.outputs.version }}"
           latest="${{ steps.latest.outputs.version }}"
-          echo "current_version=$current" >> $GITHUB_OUTPUT
 
           if [ -z "$current" ]; then
             echo "::error::Could not determine current version from spec file"
@@ -69,175 +74,7 @@ jobs:
           fi
 
           if [ "$current" != "$latest" ]; then
-            echo "new_version=$latest" >> $GITHUB_OUTPUT
-            echo "Update available: $current -> $latest"
-          else
-            echo "No update available (current: $current)"
-          fi
-
-  check-flux-core:
-    name: Check flux-core updates
-    runs-on: ubuntu-latest
-    outputs:
-      new_version: ${{ steps.check.outputs.new_version }}
-      current_version: ${{ steps.check.outputs.current_version }}
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Get current version
-        id: current
-        run: |
-          version=$(grep '^Version:' flux-core/flux-core.spec | awk '{print $2}')
-          echo "version=$version" >> $GITHUB_OUTPUT
-
-      - name: Get latest release
-        id: latest
-        run: |
-          response=$(curl -sf "https://api.github.com/repos/flux-framework/flux-core/releases?per_page=1") || {
-            echo "Failed to fetch releases from GitHub API"
-            echo "version=" >> $GITHUB_OUTPUT
-            exit 0
-          }
-          version=$(echo "$response" | jq -r '.[0].tag_name // empty' | sed 's/^v//')
-          if [ -z "$version" ]; then
-            echo "Could not parse version from GitHub API response"
-            echo "version=" >> $GITHUB_OUTPUT
-          else
-            echo "Latest version: $version"
-            echo "version=$version" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Check for update
-        id: check
-        run: |
-          current="${{ steps.current.outputs.version }}"
-          latest="${{ steps.latest.outputs.version }}"
-          echo "current_version=$current" >> $GITHUB_OUTPUT
-
-          if [ -z "$current" ]; then
-            echo "::error::Could not determine current version from spec file"
-            exit 1
-          fi
-
-          if [ -z "$latest" ]; then
-            echo "::warning::Could not fetch latest version from GitHub API, skipping update check"
-            exit 0
-          fi
-
-          if [ "$current" != "$latest" ]; then
-            echo "new_version=$latest" >> $GITHUB_OUTPUT
-            echo "Update available: $current -> $latest"
-          else
-            echo "No update available (current: $current)"
-          fi
-
-  check-flux-sched:
-    name: Check flux-sched updates
-    runs-on: ubuntu-latest
-    outputs:
-      new_version: ${{ steps.check.outputs.new_version }}
-      current_version: ${{ steps.check.outputs.current_version }}
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Get current version
-        id: current
-        run: |
-          version=$(grep '^Version:' flux-sched/flux-sched.spec | awk '{print $2}')
-          echo "version=$version" >> $GITHUB_OUTPUT
-
-      - name: Get latest release
-        id: latest
-        run: |
-          response=$(curl -sf "https://api.github.com/repos/flux-framework/flux-sched/releases?per_page=1") || {
-            echo "Failed to fetch releases from GitHub API"
-            echo "version=" >> $GITHUB_OUTPUT
-            exit 0
-          }
-          version=$(echo "$response" | jq -r '.[0].tag_name // empty' | sed 's/^v//')
-          if [ -z "$version" ]; then
-            echo "Could not parse version from GitHub API response"
-            echo "version=" >> $GITHUB_OUTPUT
-          else
-            echo "Latest version: $version"
-            echo "version=$version" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Check for update
-        id: check
-        run: |
-          current="${{ steps.current.outputs.version }}"
-          latest="${{ steps.latest.outputs.version }}"
-          echo "current_version=$current" >> $GITHUB_OUTPUT
-
-          if [ -z "$current" ]; then
-            echo "::error::Could not determine current version from spec file"
-            exit 1
-          fi
-
-          if [ -z "$latest" ]; then
-            echo "::warning::Could not fetch latest version from GitHub API, skipping update check"
-            exit 0
-          fi
-
-          if [ "$current" != "$latest" ]; then
-            echo "new_version=$latest" >> $GITHUB_OUTPUT
-            echo "Update available: $current -> $latest"
-          else
-            echo "No update available (current: $current)"
-          fi
-
-  check-flux-accounting:
-    name: Check flux-accounting updates
-    runs-on: ubuntu-latest
-    outputs:
-      new_version: ${{ steps.check.outputs.new_version }}
-      current_version: ${{ steps.check.outputs.current_version }}
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Get current version
-        id: current
-        run: |
-          version=$(grep '^Version:' flux-accounting/flux-accounting.spec | awk '{print $2}')
-          echo "version=$version" >> $GITHUB_OUTPUT
-
-      - name: Get latest release
-        id: latest
-        run: |
-          response=$(curl -sf "https://api.github.com/repos/flux-framework/flux-accounting/releases?per_page=1") || {
-            echo "Failed to fetch releases from GitHub API"
-            echo "version=" >> $GITHUB_OUTPUT
-            exit 0
-          }
-          version=$(echo "$response" | jq -r '.[0].tag_name // empty' | sed 's/^v//')
-          if [ -z "$version" ]; then
-            echo "Could not parse version from GitHub API response"
-            echo "version=" >> $GITHUB_OUTPUT
-          else
-            echo "Latest version: $version"
-            echo "version=$version" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Check for update
-        id: check
-        run: |
-          current="${{ steps.current.outputs.version }}"
-          latest="${{ steps.latest.outputs.version }}"
-          echo "current_version=$current" >> $GITHUB_OUTPUT
-
-          if [ -z "$current" ]; then
-            echo "::error::Could not determine current version from spec file"
-            exit 1
-          fi
-
-          if [ -z "$latest" ]; then
-            echo "::warning::Could not fetch latest version from GitHub API, skipping update check"
-            exit 0
-          fi
-
-          if [ "$current" != "$latest" ]; then
-            echo "new_version=$latest" >> $GITHUB_OUTPUT
+            echo "version=$latest" >> $GITHUB_OUTPUT
             echo "Update available: $current -> $latest"
           else
             echo "No update available (current: $current)"
@@ -247,66 +84,61 @@ jobs:
   # Update jobs (only run if new version detected)
   # Each job: bumps version + sources, creates tracking issue + PR
   # ============================================================
-
-  update-flux-security:
-    name: Update flux-security
-    needs: [check-flux-security]
-    if: needs.check-flux-security.outputs.new_version != ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
       - name: Update spec and sources
+        if: steps.new.outputs.version != ''
         run: |
-          VERSION="${{ needs.check-flux-security.outputs.new_version }}"
-          sed -i "s/^Version:.*/Version: ${VERSION}/" flux-security/flux-security.spec
-          sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-security/flux-security.spec
+          VERSION="${{ steps.new.outputs.version }}"
+          SPECFILE="${{ matrix.package }}/${{ matrix.package }}.spec"
+          sed -i "s/^Version:.*/Version: ${VERSION}/" ${SPECFILE}
+          sed -i "s/^Release:.*/Release: 1%{?dist}/" ${SPECFILE}
           sed -i "/^%changelog$/r"<(cat <<-EOF
           * $(date +'%a %b %d %Y') Kush Gupta <kugupta@redhat.com> - ${VERSION}-1
           - Update to v${VERSION}
           
           EOF
-          ) flux-security/flux-security.spec
-          SHA256=$(curl -sL "https://github.com/flux-framework/flux-security/releases/download/v${VERSION}/flux-security-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
-          echo "SHA256 (flux-security-${VERSION}.tar.gz) = ${SHA256}" > flux-security/sources
+          ) ${SPECFILE}
+          SHA256=$(curl -sL "https://github.com/flux-framework/${{ matrix.package }}/releases/download/v${VERSION}/${{ matrix.package }}-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
+          echo "SHA256 (${{ matrix.package }}-${VERSION}.tar.gz) = ${SHA256}" > ${{ matrix.package }}/sources
 
       - name: Find or create tracking issue
+        if: steps.new.outputs.version != ''
         id: create-issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TITLE="Update flux-security to ${{ needs.check-flux-security.outputs.new_version }}"
+          TITLE="Update ${{ matrix.package }} to ${{ steps.new.outputs.version }}"
           EXISTING=$(gh issue list --search "$TITLE" --state open --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             echo "issue-number=$EXISTING" >> "$GITHUB_OUTPUT"
             echo "Reusing existing issue #$EXISTING"
           else
-            BODY="New flux-security release detected.
+            BODY="New ${{ matrix.package }} release detected.
 
-          **Current version:** ${{ needs.check-flux-security.outputs.current_version }}
-          **New version:** ${{ needs.check-flux-security.outputs.new_version }}
-          **Release:** https://github.com/flux-framework/flux-security/releases/tag/v${{ needs.check-flux-security.outputs.new_version }}
+          **Current version:** ${{ steps.current.outputs.version }}
+          **New version:** ${{ steps.new.outputs.version }}
+          **Release:** https://github.com/flux-framework/${{ matrix.package }}/releases/tag/v${{ steps.new.outputs.version }}
 
           An automated PR has been created with the version bump. Please review:
           - [ ] Check release notes for spec file changes
           - [ ] Verify patches are still needed for this version
           - [ ] Verify BuildRequires are still correct
           - [ ] Test build locally if possible"
-            NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-security | grep -oP '\d+$')
+            NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label ${{ matrix.package }} | grep -oP '\d+$')
             echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
             echo "Created issue #$NUM"
           fi
 
       - name: Create Pull Request
+        if: steps.new.outputs.version != ''
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update flux-security to ${{ needs.check-flux-security.outputs.new_version }}"
-          title: "Update flux-security to ${{ needs.check-flux-security.outputs.new_version }}"
+          commit-message: "Update ${{ matrix.package }} to ${{ steps.new.outputs.version }}"
+          title: "Update ${{ matrix.package }} to ${{ steps.new.outputs.version }}"
           body: |
-            Automated version bump for flux-security from ${{ needs.check-flux-security.outputs.current_version }} to ${{ needs.check-flux-security.outputs.new_version }}.
+            Automated version bump for ${{ matrix.package }} from ${{ steps.current.outputs.version }} to ${{ steps.new.outputs.version }}.
 
-            Release: https://github.com/flux-framework/flux-security/releases/tag/v${{ needs.check-flux-security.outputs.new_version }}
+            Release: https://github.com/flux-framework/${{ matrix.package }}/releases/tag/v${{ steps.new.outputs.version }}
 
             Closes #${{ steps.create-issue.outputs.issue-number }}
 
@@ -315,215 +147,6 @@ jobs:
             - [ ] Verify patches are still needed for this version
             - [ ] Verify BuildRequires are still correct
             - [ ] Test build locally if possible
-          branch: update-flux-security-${{ needs.check-flux-security.outputs.new_version }}
+          branch: update-${{ matrix.package }}-${{ steps.new.outputs.version }}
           delete-branch: true
 
-  update-flux-core:
-    name: Update flux-core
-    needs: [check-flux-core]
-    if: needs.check-flux-core.outputs.new_version != ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Update spec and sources
-        run: |
-          VERSION="${{ needs.check-flux-core.outputs.new_version }}"
-          sed -i "s/^Version:.*/Version: ${VERSION}/" flux-core/flux-core.spec
-          sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-core/flux-core.spec
-          sed -i "/^%changelog$/r"<(cat <<-EOF
-          * $(date +'%a %b %d %Y') Kush Gupta <kugupta@redhat.com> - ${VERSION}-1
-          - Update to v${VERSION}
-          
-          EOF
-          ) flux-core/flux-core.spec
-          SHA256=$(curl -sL "https://github.com/flux-framework/flux-core/releases/download/v${VERSION}/flux-core-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
-          echo "SHA256 (flux-core-${VERSION}.tar.gz) = ${SHA256}" > flux-core/sources
-
-      - name: Find or create tracking issue
-        id: create-issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TITLE="Update flux-core to ${{ needs.check-flux-core.outputs.new_version }}"
-          EXISTING=$(gh issue list --search "$TITLE" --state open --json number --jq '.[0].number // empty')
-          if [ -n "$EXISTING" ]; then
-            echo "issue-number=$EXISTING" >> "$GITHUB_OUTPUT"
-            echo "Reusing existing issue #$EXISTING"
-          else
-            BODY="New flux-core release detected.
-
-          **Current version:** ${{ needs.check-flux-core.outputs.current_version }}
-          **New version:** ${{ needs.check-flux-core.outputs.new_version }}
-          **Release:** https://github.com/flux-framework/flux-core/releases/tag/v${{ needs.check-flux-core.outputs.new_version }}
-
-          An automated PR has been created with the version bump. Please review:
-          - [ ] Check release notes for spec file changes
-          - [ ] Verify patches are still needed for this version
-          - [ ] Verify BuildRequires are still correct
-          - [ ] Test build locally if possible"
-            NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-core | grep -oP '\d+$')
-            echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
-            echo "Created issue #$NUM"
-          fi
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update flux-core to ${{ needs.check-flux-core.outputs.new_version }}"
-          title: "Update flux-core to ${{ needs.check-flux-core.outputs.new_version }}"
-          body: |
-            Automated version bump for flux-core from ${{ needs.check-flux-core.outputs.current_version }} to ${{ needs.check-flux-core.outputs.new_version }}.
-
-            Release: https://github.com/flux-framework/flux-core/releases/tag/v${{ needs.check-flux-core.outputs.new_version }}
-
-            Closes #${{ steps.create-issue.outputs.issue-number }}
-
-            Please review:
-            - [ ] Check release notes for spec file changes
-            - [ ] Verify patches are still needed for this version
-            - [ ] Verify BuildRequires are still correct
-            - [ ] Test build locally if possible
-          branch: update-flux-core-${{ needs.check-flux-core.outputs.new_version }}
-          delete-branch: true
-
-  update-flux-sched:
-    name: Update flux-sched
-    needs: [check-flux-sched]
-    if: needs.check-flux-sched.outputs.new_version != ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Update spec and sources
-        run: |
-          VERSION="${{ needs.check-flux-sched.outputs.new_version }}"
-          sed -i "s/^Version:.*/Version: ${VERSION}/" flux-sched/flux-sched.spec
-          sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-sched/flux-sched.spec
-          sed -i "/^%changelog$/r"<(cat <<-EOF
-          * $(date +'%a %b %d %Y') Kush Gupta <kugupta@redhat.com> - ${VERSION}-1
-          - Update to v${VERSION}
-          
-          EOF
-          ) flux-sched/flux-sched.spec
-          SHA256=$(curl -sL "https://github.com/flux-framework/flux-sched/releases/download/v${VERSION}/flux-sched-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
-          echo "SHA256 (flux-sched-${VERSION}.tar.gz) = ${SHA256}" > flux-sched/sources
-
-      - name: Find or create tracking issue
-        id: create-issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TITLE="Update flux-sched to ${{ needs.check-flux-sched.outputs.new_version }}"
-          EXISTING=$(gh issue list --search "$TITLE" --state open --json number --jq '.[0].number // empty')
-          if [ -n "$EXISTING" ]; then
-            echo "issue-number=$EXISTING" >> "$GITHUB_OUTPUT"
-            echo "Reusing existing issue #$EXISTING"
-          else
-            BODY="New flux-sched release detected.
-
-          **Current version:** ${{ needs.check-flux-sched.outputs.current_version }}
-          **New version:** ${{ needs.check-flux-sched.outputs.new_version }}
-          **Release:** https://github.com/flux-framework/flux-sched/releases/tag/v${{ needs.check-flux-sched.outputs.new_version }}
-
-          An automated PR has been created with the version bump. Please review:
-          - [ ] Check release notes for spec file changes
-          - [ ] Verify patches are still needed for this version
-          - [ ] Verify BuildRequires are still correct
-          - [ ] Test build locally if possible"
-            NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-sched | grep -oP '\d+$')
-            echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
-            echo "Created issue #$NUM"
-          fi
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update flux-sched to ${{ needs.check-flux-sched.outputs.new_version }}"
-          title: "Update flux-sched to ${{ needs.check-flux-sched.outputs.new_version }}"
-          body: |
-            Automated version bump for flux-sched from ${{ needs.check-flux-sched.outputs.current_version }} to ${{ needs.check-flux-sched.outputs.new_version }}.
-
-            Release: https://github.com/flux-framework/flux-sched/releases/tag/v${{ needs.check-flux-sched.outputs.new_version }}
-
-            Closes #${{ steps.create-issue.outputs.issue-number }}
-
-            Please review:
-            - [ ] Check release notes for spec file changes
-            - [ ] Verify patches are still needed for this version
-            - [ ] Verify BuildRequires are still correct
-            - [ ] Test build locally if possible
-          branch: update-flux-sched-${{ needs.check-flux-sched.outputs.new_version }}
-          delete-branch: true
-
-  update-flux-accounting:
-    name: Update flux-accounting
-    needs: [check-flux-accounting]
-    if: needs.check-flux-accounting.outputs.new_version != ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Update spec and sources
-        run: |
-          VERSION="${{ needs.check-flux-accounting.outputs.new_version }}"
-          sed -i "s/^Version:.*/Version: ${VERSION}/" flux-accounting/flux-accounting.spec
-          sed -i "s/^Release:.*/Release: 1%{?dist}/" flux-accounting/flux-accounting.spec
-          sed -i "/^%changelog$/r"<(cat <<-EOF
-          * $(date +'%a %b %d %Y') Kush Gupta <kugupta@redhat.com> - ${VERSION}-1
-          - Update to v${VERSION}
-          
-          EOF
-          ) flux-accounting/flux-accounting.spec
-          SHA256=$(curl -sL "https://github.com/flux-framework/flux-accounting/releases/download/v${VERSION}/flux-accounting-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
-          echo "SHA256 (flux-accounting-${VERSION}.tar.gz) = ${SHA256}" > flux-accounting/sources
-
-      - name: Find or create tracking issue
-        id: create-issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TITLE="Update flux-accounting to ${{ needs.check-flux-accounting.outputs.new_version }}"
-          EXISTING=$(gh issue list --search "$TITLE" --state open --json number --jq '.[0].number // empty')
-          if [ -n "$EXISTING" ]; then
-            echo "issue-number=$EXISTING" >> "$GITHUB_OUTPUT"
-            echo "Reusing existing issue #$EXISTING"
-          else
-            BODY="New flux-accounting release detected.
-
-          **Current version:** ${{ needs.check-flux-accounting.outputs.current_version }}
-          **New version:** ${{ needs.check-flux-accounting.outputs.new_version }}
-          **Release:** https://github.com/flux-framework/flux-accounting/releases/tag/v${{ needs.check-flux-accounting.outputs.new_version }}
-
-          An automated PR has been created with the version bump. Please review:
-          - [ ] Check release notes for spec file changes
-          - [ ] Verify patches are still needed for this version
-          - [ ] Verify BuildRequires are still correct
-          - [ ] Test build locally if possible"
-            NUM=$(gh issue create --title "$TITLE" --body "$BODY" --label enhancement --label flux-accounting | grep -oP '\d+$')
-            echo "issue-number=$NUM" >> "$GITHUB_OUTPUT"
-            echo "Created issue #$NUM"
-          fi
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update flux-accounting to ${{ needs.check-flux-accounting.outputs.new_version }}"
-          title: "Update flux-accounting to ${{ needs.check-flux-accounting.outputs.new_version }}"
-          body: |
-            Automated version bump for flux-accounting from ${{ needs.check-flux-accounting.outputs.current_version }} to ${{ needs.check-flux-accounting.outputs.new_version }}.
-
-            Release: https://github.com/flux-framework/flux-accounting/releases/tag/v${{ needs.check-flux-accounting.outputs.new_version }}
-
-            Closes #${{ steps.create-issue.outputs.issue-number }}
-
-            Please review:
-            - [ ] Check release notes for spec file changes
-            - [ ] Verify patches are still needed for this version
-            - [ ] Verify BuildRequires are still correct
-            - [ ] Test build locally if possible
-          branch: update-flux-accounting-${{ needs.check-flux-accounting.outputs.new_version }}
-          delete-branch: true

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -20,7 +20,7 @@ jobs:
   # Check for version updates (runs in parallel)
   # ============================================================
   check-all:
-    name: Check ${{ matrix.package }} updates
+    name: Check ${{ matrix.package }}
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
@@ -34,60 +34,47 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Get current version
-        id: current
-        run: |
-          version=$(grep '^Version:' ${{ matrix.package }}/${{ matrix.package }}.spec | awk '{print $2}')
-          echo "version=$version" >> $GITHUB_OUTPUT
-
-      - name: Get latest release
-        id: latest
-        run: |
-          response=$(curl -sf "https://api.github.com/repos/flux-framework/${{ matrix.package }}/releases?per_page=1") || {
-            echo "Failed to fetch releases from GitHub API"
-            echo "version=" >> $GITHUB_OUTPUT
-            exit 0
-          }
-          version=$(echo "$response" | jq -r '.[0].tag_name // empty' | sed 's/^v//')
-          if [ -z "$version" ]; then
-            echo "Could not parse version from GitHub API response"
-            echo "version=" >> $GITHUB_OUTPUT
-          else
-            echo "Latest version: $version"
-            echo "version=$version" >> $GITHUB_OUTPUT
-          fi
-
       - name: Check for update
-        id: new
+        id: check
         run: |
-          current="${{ steps.current.outputs.version }}"
-          latest="${{ steps.latest.outputs.version }}"
-
+          current=$(grep '^Version:' ${{ matrix.package }}/${{ matrix.package }}.spec | awk '{print $2}')
           if [ -z "$current" ]; then
             echo "::error::Could not determine current version from spec file"
+          else
+            echo "Current version: $current"
+            echo "current=$current" >> $GITHUB_OUTPUT
+          fi
+          response=$(curl -sf "https://api.github.com/repos/flux-framework/${{ matrix.package }}/releases?per_page=1") || {
+            response=""
+            echo "::warning::Failed to fetch latest release from GitHub API"
+          }
+          if [ -n "$response" ]; then
+            latest=$(echo "$response" | jq -r '.[0].tag_name // empty' | sed 's/^v//')
+            if [ -z "$latest" ]; then
+            echo "::error::Could not parse version from GitHub API response"
+            else
+              echo "Latest version: $latest"
+            fi
+          fi
+          if [ -z "$current" ] || [ -z "$latest" ]; then
+            echo "::error::Could not determine both current and latest versions, skipping update check"
             exit 1
           fi
-
-          if [ -z "$latest" ]; then
-            echo "::warning::Could not fetch latest version from GitHub API, skipping update check"
-            exit 0
-          fi
-
           if [ "$current" != "$latest" ]; then
-            echo "version=$latest" >> $GITHUB_OUTPUT
+            echo "latest=$latest" >> $GITHUB_OUTPUT
             echo "Update available: $current -> $latest"
           else
             echo "No update available (current: $current)"
           fi
 
   # ============================================================
-  # Update jobs (only run if new version detected)
-  # Each job: bumps version + sources, creates tracking issue + PR
+  # Update steps (only run if new version detected)
+  # Each step bumps version + sources, creates tracking issue + PR
   # ============================================================
       - name: Update spec and sources
-        if: steps.new.outputs.version != ''
+        if: steps.check.outputs.latest != ''
         run: |
-          VERSION="${{ steps.new.outputs.version }}"
+          VERSION="${{ steps.check.outputs.latest }}"
           SPECFILE="${{ matrix.package }}/${{ matrix.package }}.spec"
           sed -i "s/^Version:.*/Version: ${VERSION}/" ${SPECFILE}
           sed -i "s/^Release:.*/Release: 1%{?dist}/" ${SPECFILE}
@@ -101,12 +88,12 @@ jobs:
           echo "SHA256 (${{ matrix.package }}-${VERSION}.tar.gz) = ${SHA256}" > ${{ matrix.package }}/sources
 
       - name: Find or create tracking issue
-        if: steps.new.outputs.version != ''
+        if: steps.check.outputs.latest != ''
         id: create-issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TITLE="Update ${{ matrix.package }} to ${{ steps.new.outputs.version }}"
+          TITLE="Update ${{ matrix.package }} to ${{ steps.check.outputs.latest }}"
           EXISTING=$(gh issue list --search "$TITLE" --state open --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             echo "issue-number=$EXISTING" >> "$GITHUB_OUTPUT"
@@ -114,9 +101,9 @@ jobs:
           else
             BODY="New ${{ matrix.package }} release detected.
 
-          **Current version:** ${{ steps.current.outputs.version }}
-          **New version:** ${{ steps.new.outputs.version }}
-          **Release:** https://github.com/flux-framework/${{ matrix.package }}/releases/tag/v${{ steps.new.outputs.version }}
+          **Current version:** ${{ steps.check.outputs.current }}
+          **New version:** ${{ steps.check.outputs.latest }}
+          **Release:** https://github.com/flux-framework/${{ matrix.package }}/releases/tag/v${{ steps.check.outputs.latest }}
 
           An automated PR has been created with the version bump. Please review:
           - [ ] Check release notes for spec file changes
@@ -129,16 +116,16 @@ jobs:
           fi
 
       - name: Create Pull Request
-        if: steps.new.outputs.version != ''
+        if: steps.check.outputs.latest != ''
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update ${{ matrix.package }} to ${{ steps.new.outputs.version }}"
-          title: "Update ${{ matrix.package }} to ${{ steps.new.outputs.version }}"
+          commit-message: "Update ${{ matrix.package }} to ${{ steps.check.outputs.latest }}"
+          title: "Update ${{ matrix.package }} to ${{ steps.check.outputs.latest }}"
           body: |
-            Automated version bump for ${{ matrix.package }} from ${{ steps.current.outputs.version }} to ${{ steps.new.outputs.version }}.
+            Automated version bump for ${{ matrix.package }} from ${{ steps.check.outputs.current }} to ${{ steps.check.outputs.latest }}.
 
-            Release: https://github.com/flux-framework/${{ matrix.package }}/releases/tag/v${{ steps.new.outputs.version }}
+            Release: https://github.com/flux-framework/${{ matrix.package }}/releases/tag/v${{ steps.check.outputs.latest }}
 
             Closes #${{ steps.create-issue.outputs.issue-number }}
 
@@ -147,6 +134,6 @@ jobs:
             - [ ] Verify patches are still needed for this version
             - [ ] Verify BuildRequires are still correct
             - [ ] Test build locally if possible
-          branch: update-${{ matrix.package }}-${{ steps.new.outputs.version }}
+          branch: update-${{ matrix.package }}-${{ steps.check.outputs.latest }}
           delete-branch: true
 


### PR DESCRIPTION
Automatically reset `Release` to 1 and create basic changelog entry for new versions.

Now also uses a `matrix` strategy to greatly simplify the workflow file and improve maintainibility.

## Summary by Sourcery

Automate spec file release and changelog updates in the check-updates workflow for Flux components.

Enhancements:
- Automatically reset the RPM Release field to `1%{?dist}` when bumping versions for flux-security, flux-core, flux-sched, and flux-accounting in the update workflow.
- Automatically prepend a basic changelog entry for new versions in the corresponding spec files during CI-driven updates.
- Remove the manual "Add changelog entry" checklist item from generated issues and PR bodies, since changelog entries are now created by the workflow.

## Summary by Sourcery

Simplify and generalize the check-updates workflow for Flux components using a single matrix-driven job that also automates spec metadata updates when new releases are detected.

Enhancements:
- Automatically reset the RPM Release field to a standard value when bumping Flux component versions in CI-driven updates.
- Automatically prepend a basic changelog entry to the spec files for new Flux component releases during the update workflow.
- Use a single matrix-based job to handle update checks and follow-up actions for all Flux components, reducing duplication in the workflow configuration.

CI:
- Refactor the check-updates GitHub Actions workflow to consolidate per-component jobs into one matrix strategy while preserving per-component issue and PR creation.
- Drop the manual changelog checklist step in auto-generated issues and PRs now that changelog entries are created by the workflow.