### PR TITLE
`flux-core` minimum version for `flux-sched` and remove missing shebangs workarounds

### DIFF
--- a/FEDORA_CHANGES.md
+++ b/FEDORA_CHANGES.md
@@ -101,8 +101,8 @@ Each package has a `.rpmlintrc` file alongside its spec to suppress known false 
 
 - **LTO disabled**: `%global _lto_cflags %{nil}` -- LTO causes test failures
 - **Strict-aliasing disabled**: `%global build_cflags %{build_cflags} -fno-strict-aliasing` -- bundled libev has known violations
-- **Requires filter**: `%global __requires_exclude /bin/false` -- RHEL provides `/usr/bin/false` not `/bin/false`
-- **Shebang mangling exclusion**: `%global __brp_mangle_shebangs_exclude_from ^%{_libexecdir}/flux/` -- flux Python subcommands run through `flux python` wrapper, not directly
+- **~~Requires filter~~**: ~~`%global __requires_exclude /bin/false`~~ -- removed; upstream no longer uses `#!/bin/false` shebangs (flux-core#7643)
+- **~~Shebang mangling exclusion~~**: ~~`%global __brp_mangle_shebangs_exclude_from ^%{_libexecdir}/flux/`~~ -- removed; cmd scripts now have proper shebangs (flux-core#7643, flux-accounting#873)
 - **rpath removal**: Uses `chrpath -d` with improved error handling (`xargs -I{}` instead of deprecated `-ti`, `2>/dev/null || true`)
 - **Custom preun**: Stops `flux.service` gracefully before upgrade/removal, with `2>/dev/null` on systemctl check
 - **Lua paths**: Changed from hardcoded `5.3` to wildcard `*` for portability

--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -6,11 +6,6 @@ License: LGPL-3.0-only
 URL:     https://github.com/flux-framework/flux-accounting
 Source0: %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
-# Exclude flux Python subcommands from shebang mangling - these files are run
-# through the `flux python` wrapper and don't have shebangs by design. Without
-# this, brp-mangle-shebangs strips the executable bit we set, breaking `flux account`.
-%global __brp_mangle_shebangs_exclude_from ^%{_libexecdir}/flux/
-
 %global flux_core_minver 0.81.0
 
 BuildRequires: pkgconfig(jansson) >= 2.10

--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -6,10 +6,6 @@ License: LGPL-3.0-only
 URL:     https://github.com/flux-framework/flux-core
 Source0: %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
-# Prevent auto-Requires on /bin/false (cmd scripts use #!/bin/false shebangs;
-# RHEL provides /usr/bin/false)
-%global __requires_exclude /bin/false
-
 # LTO causes a bunch of tests to fail so it should not be used
 %global _lto_cflags %{nil}
 
@@ -17,11 +13,6 @@ Source0: %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 # known strict-aliasing violations. Upstream already uses -Wno-strict-aliasing
 # in their build but Fedora's optflags adds -O2 which enables -fstrict-aliasing.
 %global build_cflags %{build_cflags} -fno-strict-aliasing
-
-# Exclude flux Python subcommands from shebang mangling - these files are run
-# through the `flux python` wrapper and don't have shebangs by design. Without
-# this, brp-mangle-shebangs strips the executable bit we set, breaking `flux modprobe`.
-%global __brp_mangle_shebangs_exclude_from ^%{_libexecdir}/flux/
 
 %global cffi_minver        1.1
 %global ply_minver         3.9

--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -123,8 +123,6 @@ find %{buildroot} -name '*.la' -delete
 
 # Python subcommand permissions - flux requires .py files to be executable
 # (checked via access(path, R_OK|X_OK) in exec_subcommand_py)
-# These files are run through `flux python` wrapper, not directly, so they
-# don't have shebangs. We set them executable and exclude from shebang mangling.
 find %{buildroot}%{_libexecdir}/flux/cmd -name '*.py' -exec chmod 755 {} \;
 find %{buildroot}%{_libexecdir}/flux/modprobe -name '*.py' -exec chmod 755 {} \;
 

--- a/flux-sched/flux-sched.spec
+++ b/flux-sched/flux-sched.spec
@@ -13,14 +13,6 @@ Patch0:  gcc15-ice-workaround.patch
 # GNUInstallDirs sets normal variable that shadows the CACHE FORCE override
 Patch1:  cmake-install-libdir-fix.patch
 
-# Redhat only provides /usr/bin/false, but tests look for /bin/false
-%global __requires_exclude /bin/false
-
-# Exclude flux Python subcommands from shebang mangling - these files are run
-# through the `flux python` wrapper and don't have shebangs by design. Without
-# this, brp-mangle-shebangs strips the executable bit, breaking `flux ion-resource`.
-%global __brp_mangle_shebangs_exclude_from ^%{_libexecdir}/flux/
-
 # Can't use binary annotations for some reason:
 %undefine _annotated_build
 

--- a/flux-sched/flux-sched.spec
+++ b/flux-sched/flux-sched.spec
@@ -26,7 +26,7 @@ Patch1:  cmake-install-libdir-fix.patch
 
 ExcludeArch: ppc64le
 
-%global flux_core_minver 0.75.0
+%global flux_core_minver 0.78.0
 %global boost_minver     1.66
 %global pyyaml_minver    3.10
 


### PR DESCRIPTION
The correct minimum `flux-core` version currently required by `flux-sched` was determined to be 0.78.0.
See discussion here: https://github.com/flux-framework/flux-sched/issues/1501#issuecomment-4678801373

And with the following fixes merged upstream the workarounds for missing shebangs should no longer be necessary:
flux-framework/flux-core#7643
flux-framework/flux-accounting#873

## Summary by Sourcery

Update packaging to require newer flux-core and drop legacy shebang-related RPM workarounds.

Enhancements:
- Increase flux-sched minimum flux-core dependency to version 0.78.0.
- Remove RPM shebang-mangling and /bin/false requires-exclude workarounds from flux-core and flux-accounting spec files.