### PR TITLE
check-updates: drop patches already applied upstream when bumping versions

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -159,12 +159,47 @@ jobs:
         run: |
           VERSION="${{ steps.check.outputs.latest }}"
           PACKAGE="${{ matrix.package }}"
+          SPEC="${PACKAGE}/${PACKAGE}.spec"
 
-          sed -i "s/^Version:.*/Version: ${VERSION}/" ${PACKAGE}/${PACKAGE}.spec
-          sed -i 's/^Release:.*/Release: 1%{?dist}/' ${PACKAGE}/${PACKAGE}.spec
+          sed -i "s/^Version:.*/Version: ${VERSION}/" "$SPEC"
+          sed -i 's/^Release:.*/Release: 1%{?dist}/' "$SPEC"
 
-          SHA256=$(curl -sL "https://github.com/flux-framework/${PACKAGE}/releases/download/v${VERSION}/${PACKAGE}-${VERSION}.tar.gz" | sha256sum | awk '{print $1}')
+          TARBALL="/tmp/${PACKAGE}-${VERSION}.tar.gz"
+          curl -sfL -o "$TARBALL" "https://github.com/flux-framework/${PACKAGE}/releases/download/v${VERSION}/${PACKAGE}-${VERSION}.tar.gz" || {
+            echo "::error::Failed to download release tarball for ${PACKAGE} ${VERSION}"
+            exit 1
+          }
+          SHA256=$(sha256sum "$TARBALL" | awk '{print $1}')
           echo "SHA256 (${PACKAGE}-${VERSION}.tar.gz) = ${SHA256}" > ${PACKAGE}/sources
+
+          # Check each patch against the new release. A patch that
+          # reverse-applies cleanly has been merged upstream and would
+          # break %prep ("Reversed (or previously applied) patch
+          # detected!"), so drop it (spec entry, preceding comment
+          # block, and patch file) and record a changelog note.
+          # Patches that no longer apply at all are left in place and
+          # flagged for manual review.
+          SRCDIR=$(mktemp -d)
+          tar -xzf "$TARBALL" -C "$SRCDIR"
+          : > /tmp/dropped_patches.txt
+          grep -E '^Patch[0-9]*:' "$SPEC" | awk '{print $2}' | while IFS= read -r patchfile; do
+            # --fuzz=0 matches how rpmbuild %autosetup applies patches
+            if patch -p1 -d "${SRCDIR}/${PACKAGE}-${VERSION}" --dry-run --fuzz=0 -N -s -f < "${PACKAGE}/${patchfile}" >/dev/null 2>&1; then
+              echo "Patch still applies cleanly, keeping: ${patchfile}"
+            elif patch -p1 -R -d "${SRCDIR}/${PACKAGE}-${VERSION}" --dry-run --fuzz=0 -s -f < "${PACKAGE}/${patchfile}" >/dev/null 2>&1; then
+              echo "Patch already applied upstream, dropping: ${patchfile}"
+              awk -v patchfile="$patchfile" '
+                /^[[:space:]]*$/ || /^#/ { buf = buf $0 ORS; next }
+                /^Patch[0-9]*:/ && $2 == patchfile { buf = ""; next }
+                { printf "%s", buf; buf = ""; print }
+                END { printf "%s", buf }
+              ' "$SPEC" > "${SPEC}.tmp" && mv "${SPEC}.tmp" "$SPEC"
+              rm -f "${PACKAGE}/${patchfile}"
+              echo "- Drop ${patchfile} (applied upstream in ${VERSION})" >> /tmp/dropped_patches.txt
+            else
+              echo "::warning::Patch ${patchfile} does not apply cleanly to ${PACKAGE} ${VERSION}; manual review needed"
+            fi
+          done
 
           DATE=$(date -u '+%a %b %d %Y')
           {
@@ -173,11 +208,12 @@ jobs:
             cat <<'ENTRIES_EOF'
           ${{ steps.changelog.outputs.entries }}
           ENTRIES_EOF
+            cat /tmp/dropped_patches.txt
             echo ""
-            sed -n '/%changelog/,$ { /%changelog/d; p }' ${PACKAGE}/${PACKAGE}.spec
+            sed -n '/%changelog/,$ { /%changelog/d; p }' "$SPEC"
           } > /tmp/changelog
-          sed -i '/%changelog/,$ d' ${PACKAGE}/${PACKAGE}.spec
-          cat /tmp/changelog >> ${PACKAGE}/${PACKAGE}.spec
+          sed -i '/%changelog/,$ d' "$SPEC"
+          cat /tmp/changelog >> "$SPEC"
 
       - name: Find or create tracking issue
         id: create-issue


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The daily `check-updates` automation kept all existing `PatchN:` entries when generating a version-bump PR. When upstream merges one of our patches into the new release, the generated PR fails `%prep` on every distro with `Reversed (or previously applied) patch detected!`. This is exactly what broke the flux-sched 0.53.0 PR (#69): `cmake-install-libdir-fix.patch` landed upstream in [flux-framework/flux-sched#1507](https://github.com/flux-framework/flux-sched/pull/1507).

## Changes to `check-updates.yml` ("Update spec and sources" step)

- Download the release tarball once with `curl -sfL` (a missing asset now fails the job loudly instead of hashing an HTML error page into `sources`), then reuse it for both the SHA256 and the patch checks.
- Test each `PatchN:` against the extracted new tarball with `--fuzz=0` (matching how rpmbuild's `%autosetup` applies patches):
  - **Still applies cleanly** → keep it.
  - **Reverse-applies cleanly** → the patch is already upstream: remove the `Patch` line and its immediately preceding comment block from the spec, delete the patch file, and add a `- Drop <patch> (applied upstream in <version>)` changelog note.
  - **Neither** → keep it and emit a workflow warning so a human reviews the conflict.

## Verification

- Simulated the updated step locally against main's flux-sched 0.52.0 spec with the 0.53.0 tarball: it drops the patch and produces a spec **byte-identical** to the manual fix pushed to #69, along with the correct `sources` checksum.
- Verified the keep path (a fresh `diff -u` patch against the 0.53.0 tree is kept) and the conflict path (a non-applying patch triggers the warning, thanks to `--fuzz=0`, which was required to avoid fuzzy false-positives).
- `actionlint` (with shellcheck) passes; the only findings are pre-existing informational ones in untouched steps, identical to main.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa9f7-3054-7783-a005-4b4c4c1b4922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa9f7-3054-7783-a005-4b4c4c1b4922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Automatically drop patches already applied upstream when generating version-bump PRs in the check-updates workflow to prevent %prep failures.

Enhancements:
- Download release tarballs once with stricter error handling in the check-updates workflow and reuse them for checksum and patch validation.
- Detect patches that have been merged upstream by reverse-applying them against the new release, remove their spec entries and files, and record corresponding changelog notes.
- Warn when existing patches no longer apply cleanly to the new release so they can be manually reviewed instead of silently breaking builds.