### PR TITLE
build(deps): bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .github/containers
           file: .github/containers/Dockerfile.builder

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         if: steps.check.outputs.latest != ''
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update ${{ matrix.package }} to ${{ steps.check.outputs.latest }}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consolidates the four open Dependabot PRs into a single update so all GitHub Actions land at their current latest majors in one merge:

| Action | From | To | Supersedes |
|--------|------|----|------------|
| `docker/login-action` | v3 | v4 | #79 |
| `peter-evans/create-pull-request` | v7 | v8 | #80 |
| `docker/metadata-action` | v5 | v6 | #81 |
| `docker/build-push-action` | v5 | v7 | #82 |

## Review notes

- Each individual Dependabot PR was **MERGEABLE** with green checks (container build + Sourcery where applicable).
- Remaining actions were already at latest majors (`actions/checkout@v7`, `actions/cache@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `docker/setup-buildx-action@v4`, `crate-ci/typos@v1.48.0`, `ludeeus/action-shellcheck@2.0.0`).
- `peter-evans/create-pull-request@v8` only requires Actions Runner ≥ 2.327.1 for Node 24 (GitHub-hosted `ubuntu-latest` is fine).
- After this merges, Dependabot PRs #79–#82 can be closed as superseded.

## Test plan

- [ ] CI green on this PR (container workflow path-filtered; build-test may be light if only workflows changed)
- [ ] Confirm no workflow syntax / actionlint issues
- [ ] Close #79, #80, #81, #82 after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbff5-392e-7d6f-aaf4-d9a4f509ef3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbff5-392e-7d6f-aaf4-d9a4f509ef3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Update GitHub Actions used in CI workflows to their latest major versions.

CI:
- Bump docker/login-action from v3 to v4 in container build workflow.
- Bump docker/metadata-action from v5 to v6 in container build workflow.
- Bump docker/build-push-action from v5 to v7 in container build workflow.
- Bump peter-evans/create-pull-request from v7 to v8 in update-check workflow.