### PR TITLE
core: bump min version reqs for zeromq to v4.2.0 and hwloc to v2.1.0

### DIFF
--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -22,7 +22,7 @@ BuildRequires: pkgconfig(flux-security) >= 0.14
 
 BuildRequires: pkgconfig(libzmq) >= 4.2.0
 BuildRequires: pkgconfig(jansson) >= 2.11
-BuildRequires: pkgconfig(hwloc) >= 1.11.1
+BuildRequires: pkgconfig(hwloc) >= 2.1.0
 BuildRequires: pkgconfig(sqlite3) >= 3.6.0
 BuildRequires: pkgconfig(bash-completion)
 BuildRequires: pkgconfig(liblz4)
@@ -266,6 +266,9 @@ fi
 %{_mandir}/man3/*.3*
 
 %changelog
+* Mon Aug 3 2026 Sam Maloney <s.maloney@fz-juelich.de> - 0.87.0-3
+- Bump version requirements for libzmq to 4.2.0 and hwloc to 2.1.0
+
 * Sat Aug 01 2026 Cursor Agent <cursoragent@cursor.com> - 0.87.0-2
 - Run systemd-tmpfiles --create for flux.conf in %%post so runtime
   directories exist at install time instead of after the next boot

--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -20,7 +20,7 @@ Source0: %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires: pkgconfig(flux-security) >= 0.14
 
-BuildRequires: pkgconfig(libzmq) >= 4.0.4
+BuildRequires: pkgconfig(libzmq) >= 4.2.0
 BuildRequires: pkgconfig(jansson) >= 2.11
 BuildRequires: pkgconfig(hwloc) >= 1.11.1
 BuildRequires: pkgconfig(sqlite3) >= 3.6.0


### PR DESCRIPTION
Minimum version requirements were bumped for `libzmq` to v4.2.0 in: https://github.com/flux-framework/flux-core/commit/8801e54e8963ce6ecc4d2e55798721d7ae39d18d and for `hwloc` to v2.1.0 in https://github.com/flux-framework/flux-core/pull/7756

## Summary by Sourcery

Build:
- Raise the pkgconfig(libzmq) BuildRequires version from 4.0.4 to 4.2.0.