### PR TITLE
core: bump Release to 3 to match changelog

### DIFF
--- a/flux-core/flux-core.spec
+++ b/flux-core/flux-core.spec
@@ -1,6 +1,6 @@
 Name:    flux-core
 Version: 0.87.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 Summary: Flux Resource Manager Framework
 License: LGPL-3.0-only
 URL:     https://github.com/flux-framework/flux-core


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #84: that PR added the `0.87.0-3` changelog entry and bumped the libzmq/hwloc `BuildRequires`, but left `Release` at `2`.

This aligns `Release` with the changelog so the package NVR matches.

Thanks again @sam-maloney!
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fca0b-cf85-76bd-b782-5244e890fc0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fca0b-cf85-76bd-b782-5244e890fc0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Build:
- Update flux-core spec file Release field from 2 to 3 to reflect the latest changelog.