### PR TITLE
Update flux-accounting to 0.60.0

### DIFF
--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -1,6 +1,6 @@
 Name:    flux-accounting
-Version: 0.59.1
-Release: 2%{?dist}
+Version: 0.60.0
+Release: 1%{?dist}
 Summary: Bank/Accounting Interface for the Flux Resource Manager
 License: LGPL-3.0-only
 URL:     https://github.com/flux-framework/flux-accounting
@@ -122,6 +122,15 @@ find %{buildroot}%{_libexecdir}/flux/cmd -name '*.py' -exec chmod 755 {} \;
 %{_mandir}/man1/*.1*
 
 %changelog
+* Thu Aug 06 2026 github-actions[bot] <github-actions[bot]@users.noreply.github.com> - 0.60.0-1
+- Update to v0.60.0
+- plugin: add option to toggle rejecting unknown queues during job validation
+- commands: add fair-share emulator
+- export-db: add -F/--fairshare-emulate option
+- Fix: update-db: add logging infrastructure
+- Fix: edit-config: remove confirmation prompt
+- Fix: update-db: improve update_columns(), add more logging during database update
+
 * Sat Aug 01 2026 Cursor Agent <cursoragent@cursor.com> - 0.59.1-2
 - Install the rc1.d priority-update hook as a regular file instead of
   %%config (executable scripts must not be config files)

--- a/flux-accounting/flux-accounting.spec
+++ b/flux-accounting/flux-accounting.spec
@@ -109,6 +109,7 @@ find %{buildroot}%{_libexecdir}/flux/cmd -name '*.py' -exec chmod 755 {} \;
 %{_libexecdir}/flux/cmd/flux-account-service.py
 %{_libexecdir}/flux/cmd/flux-account-fetch-job-records.py
 %{_libexecdir}/flux/cmd/flux-account-update-usage.py
+%{_libexecdir}/flux/cmd/flux-account-fairshare-emulate.py
 
 # rc hook: executable script, so intentionally not %%config (rpmlint
 # executable-marked-as-config-file; stale local edits would break priority

--- a/flux-accounting/sources
+++ b/flux-accounting/sources
@@ -1,1 +1,1 @@
-SHA256 (flux-accounting-0.59.1.tar.gz) = 8f47d7b019711bc33985d75dd576de3a6defdc6ef53e4beaff6254e3185dcdac
+SHA256 (flux-accounting-0.60.0.tar.gz) = fbeba425cc40377abc9e7486866ecd4372d7a494b2d5a0aeafc4103e141b34ef


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Packages flux-accounting 0.60.0 and includes the new `flux-account-fairshare-emulate` command in `%files`.

## Changes
- Bump `flux-accounting` Version to 0.60.0 / Release 1
- Update sources SHA256 for the new tarball
- Add `%{_libexecdir}/flux/cmd/flux-account-fairshare-emulate.py` so the RPM no longer fails on unpackaged files (CI failure on the automated bump)

## Notes
- Man page is already covered by `%{_mandir}/man1/*.1*`
- Python module `fairshare_emulator.py` is covered by `%{python3_sitearch}/fluxacct`
- Supersedes the automated bump in #89 (same tip once that branch was updated with this packaging fix)

Closes #87
Closes #89
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd754-9d41-7d32-9407-888ba238a00b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd754-9d41-7d32-9407-888ba238a00b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Update flux-accounting RPM packaging to version 0.60.0 and include the new fairshare emulator command in the installed files list.

New Features:
- Package and install the new flux-account-fairshare-emulate command as part of the flux-accounting RPM.

Enhancements:
- Bump flux-accounting to version 0.60.0 with the associated upstream changes described in the changelog.