### PR TITLE
check-updates: stop clobbering open update PRs, dedupe CI, harden inputs

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -53,7 +53,7 @@ jobs:
           echo "Current version: $current"
           echo "current=$current" >> $GITHUB_OUTPUT
 
-          # A failed or unparseable release lookup fails the job: exiting
+          # A failed or unparsable release lookup fails the job: exiting
           # 0 here used to hide rate-limit errors behind a green run.
           response=$(curl -sf --retry 3 \
             -H "Authorization: Bearer ${GH_TOKEN}" \
@@ -69,12 +69,43 @@ jobs:
           fi
           echo "Latest version: $latest"
 
-          if [ "$current" != "$latest" ]; then
-            echo "latest=$latest" >> $GITHUB_OUTPUT
-            echo "Update available: $current -> $latest"
-          else
-            echo "No update available (current: $current)"
+          # The tag flows into sed scripts, the changelog, branch names
+          # and URLs below; refuse anything that is not a plain dotted
+          # version.
+          if ! echo "$latest" | grep -Eq '^[0-9]+(\.[0-9]+)*$'; then
+            echo "::error::Unexpected release tag format: v${latest}"
+            exit 1
           fi
+
+          if [ "$current" = "$latest" ]; then
+            echo "No update available (current: $current)"
+            exit 0
+          fi
+
+          # Only ever move forward: /releases returns the most recently
+          # published release, which can be a patch release for an older
+          # series (e.g. 0.53.1 published after 0.54.0 is packaged).
+          if [ "$(printf '%s\n%s\n' "$current" "$latest" | sort -V | tail -n1)" != "$latest" ]; then
+            echo "Latest release ($latest) sorts below packaged version ($current); skipping"
+            exit 0
+          fi
+
+          # Leave an existing, still-mergeable update PR alone.
+          # Regenerating it every day only changes the changelog date,
+          # which force-pushes the branch (discarding any fixes a
+          # reviewer pushed to it) and burns a full build matrix. A
+          # CONFLICTING PR (e.g. #94, generated moments before an
+          # unrelated spec change landed on main) is regenerated from
+          # the current main instead.
+          mergeable=$(gh pr list --head "update-${PACKAGE}-${latest}" --state open \
+            --json mergeable --jq '.[0].mergeable // empty')
+          if [ -n "$mergeable" ] && [ "$mergeable" != "CONFLICTING" ]; then
+            echo "Open PR for update-${PACKAGE}-${latest} already exists (mergeable: ${mergeable}); skipping"
+            exit 0
+          fi
+
+          echo "latest=$latest" >> $GITHUB_OUTPUT
+          echo "Update available: $current -> $latest"
 
       - name: Generate changelog from upstream NEWS
         if: steps.check.outputs.latest != ''
@@ -83,7 +114,7 @@ jobs:
           VERSION="${{ steps.check.outputs.latest }}"
           PACKAGE="${{ matrix.package }}"
 
-          NEWS=$(curl -sf "https://raw.githubusercontent.com/flux-framework/${PACKAGE}/v${VERSION}/NEWS.md") || {
+          NEWS=$(curl -sf --retry 3 "https://raw.githubusercontent.com/flux-framework/${PACKAGE}/v${VERSION}/NEWS.md") || {
             echo "::warning::Could not fetch NEWS.md, using minimal changelog"
             echo "- Update to v${VERSION}" > /tmp/changelog_entries.txt
             { echo "entries<<CHANGELOG_EOF"; cat /tmp/changelog_entries.txt; echo "CHANGELOG_EOF"; } >> $GITHUB_OUTPUT
@@ -160,6 +191,10 @@ jobs:
             fi
           } > /tmp/changelog_entries.txt
 
+          # rpmbuild expands %macros inside %changelog too; escape any
+          # literal % from the upstream notes (e.g. "50% faster").
+          sed -i 's/%/%%/g' /tmp/changelog_entries.txt
+
           echo "Generated changelog entries:"
           cat /tmp/changelog_entries.txt
 
@@ -167,6 +202,11 @@ jobs:
 
       - name: Update spec and sources
         if: steps.check.outputs.latest != ''
+        env:
+          # Derived from the upstream NEWS.md: third-party text, so hand
+          # it to the script through the environment instead of
+          # interpolating it into the script source.
+          ENTRIES: ${{ steps.changelog.outputs.entries }}
         run: |
           VERSION="${{ steps.check.outputs.latest }}"
           PACKAGE="${{ matrix.package }}"
@@ -216,9 +256,7 @@ jobs:
           {
             echo "%changelog"
             echo "* ${DATE} github-actions[bot] <github-actions[bot]@users.noreply.github.com> - ${VERSION}-1"
-            cat <<'ENTRIES_EOF'
-          ${{ steps.changelog.outputs.entries }}
-          ENTRIES_EOF
+            printf '%s\n' "$ENTRIES"
             cat /tmp/dropped_patches.txt
             echo ""
             sed -n '/%changelog/,$ { /%changelog/d; p }' "$SPEC"
@@ -233,7 +271,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TITLE="Update ${{ matrix.package }} to ${{ steps.check.outputs.latest }}"
-          EXISTING=$(gh issue list --search "$TITLE" --state open --json number --jq '.[0].number // empty')
+          # 'gh issue list --search' is a fuzzy match; require the exact
+          # title so e.g. a 0.54.0 issue is never reused for 0.54.0.1.
+          EXISTING=$(gh issue list --search "\"$TITLE\" in:title" --state open --json number,title \
+            | jq -r --arg title "$TITLE" '[.[] | select(.title == $title)][0].number // empty')
           if [ -n "$EXISTING" ]; then
             echo "issue-number=$EXISTING" >> "$GITHUB_OUTPUT"
             echo "Reusing existing issue #$EXISTING"
@@ -266,6 +307,7 @@ jobs:
             Automated version bump for ${{ matrix.package }} from ${{ steps.check.outputs.current }} to ${{ steps.check.outputs.latest }}.
 
             Release: https://github.com/flux-framework/${{ matrix.package }}/releases/tag/v${{ steps.check.outputs.latest }}
+            Upstream changes: https://github.com/flux-framework/${{ matrix.package }}/compare/v${{ steps.check.outputs.current }}...v${{ steps.check.outputs.latest }}
 
             Closes #${{ steps.create-issue.outputs.issue-number }}
 
@@ -278,10 +320,30 @@ jobs:
           delete-branch: true
 
       - name: Trigger build CI on PR branch
-        if: steps.create-pr.outputs.pull-request-number
+        # Only when this run actually created or refreshed the PR;
+        # 'none' means the branch content was already up to date.
+        if: >-
+          steps.create-pr.outputs.pull-request-operation == 'created' ||
+          steps.create-pr.outputs.pull-request-operation == 'updated'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="update-${{ matrix.package }}-${{ steps.check.outputs.latest }}"
+          HEAD_SHA="${{ steps.create-pr.outputs.pull-request-head-sha }}"
+
+          # PRs opened with the repo GITHUB_TOKEN are documented not to
+          # start pull_request workflows, but in practice these update
+          # PRs do get one (see #94: the dispatched run and a
+          # pull_request run built the same commit twice). Give the
+          # event a moment to materialize and dispatch only if no run
+          # showed up, so each update is built exactly once either way.
+          sleep 30
+          existing=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/build-test.yml/runs?event=pull_request&head_sha=${HEAD_SHA}" \
+            --jq '.total_count')
+          if [ "${existing:-0}" -gt 0 ]; then
+            echo "build-test already triggered for ${HEAD_SHA} by the pull_request event; skipping dispatch"
+            exit 0
+          fi
           echo "Triggering Build and Test RPMs on branch: $BRANCH"
           gh workflow run build-test.yml --ref "$BRANCH"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes for the update automation, found while reviewing #94 (the flux-sched 0.54.0 bump).

## What went wrong on #94 and #88

- **#94 was born conflicted**: the scheduled run checked out main at 06:42 and generated the bump one minute before #92 landed on main and touched `flux-sched.spec`, so the PR opened `CONFLICTING` (its diff even reverted the `0.53.0-3` spec hygiene). The workflow had no notion of an existing/racing PR. (#94 itself has been fixed by merging main into its branch.)
- **Daily force-push churn**: while an update PR stays open, every scheduled run regenerates the spec with a *new changelog date*, which `create-pull-request` treats as a content change and force-pushes — `update-flux-core-0.88.0` was force-pushed and fully rebuilt on both Aug 5 and Aug 6. This would also have discarded any fixes a reviewer pushed to the branch (like the conflict fix on #94).
- **Every update was built twice**: PRs opened with `GITHUB_TOKEN` are documented *not* to trigger `pull_request` workflows, so the workflow dispatches `build-test.yml` manually — but in this repo the `pull_request` run does fire (see #94: run 31466079097 via `pull_request` and run 31466078033 via the dispatch built the same commit), so each update burned two full build matrices.

## Changes

- **Skip while an open, still-mergeable PR exists** for the same package+version: no more daily force-pushes, duplicate CI, or clobbered reviewer fixes. A `CONFLICTING` PR is still regenerated from current main, so a #94-style race self-heals on the next run.
- **Dispatch CI at most once**: only when the PR was actually `created`/`updated`, and only if the `pull_request` event didn't already start a `build-test.yml` run for the same head SHA (30s grace, checked via the Actions API). The manual dispatch remains as a fallback in case GitHub's documented `GITHUB_TOKEN` behavior kicks in.
- **Input hardening**: the upstream tag must look like a plain dotted version before it flows into `sed` scripts, branch names and the changelog; and the version must sort above the packaged one (`/releases?per_page=1` returns the most recently *published* release, which can be a patch release for an older series — previously that would have produced a downgrade PR).
- **Injection-safe changelog**: the NEWS.md-derived entries now reach the spec-update step via `env:` + `printf` instead of being textually interpolated into the `run:` script through a heredoc (third-party text in script source).
- **RPM-safe changelog**: literal `%` in upstream notes is escaped to `%%` so rpmbuild doesn't expand stray macros in `%changelog`.
- Smaller: retry the NEWS.md fetch; match tracking issues by exact title instead of `gh issue list --search` fuzzy matching; add an upstream compare link to the PR body; fix `unparseable` → `unparsable` in a comment (the pinned typos v1.49.0 accepts it, but the current typos release flags it, so the next dependabot bump would break CI).

## Validation

- `actionlint` (with shellcheck): no new findings vs main (same 6 pre-existing info/style notes).
- typos (latest): repo-wide clean.
- The new guards were exercised read-only against the live repo: the skip query returns `MERGEABLE` for #94 (so tomorrow's run leaves it alone), the dedupe query finds the existing `pull_request` run for #94's head SHA, and the version-sort/format checks behave as expected on `0.53.0→0.54.0`, `0.54.0→0.53.1` (skip), and malformed tags (reject).

Note: `build-test.yml`'s `pull_request` paths filter doesn't include `.github/workflows/check-updates.yml`, so CI won't run on this PR — validation above was done locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fefa2-6615-70d4-81e1-74edd8e2bfd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fefa2-6615-70d4-81e1-74edd8e2bfd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Improve the automated package update workflow to avoid clobbering existing PRs, ensure only forward, well-formed version bumps, and deduplicate CI runs while hardening changelog handling.

New Features:
- Skip creating or regenerating an update PR when an open, non-conflicting PR already exists for the same package and version.
- Require upstream release tags to be plain dotted versions and only create update PRs when the new version sorts above the currently packaged one.
- Add an upstream compare link between current and target versions to the auto-generated update PR body.

Enhancements:
- Retry fetching upstream NEWS.md when generating changelog entries to make updates more robust against transient network failures.
- Escape literal percent signs in generated changelog entries so they are safe for RPM %changelog parsing.
- Pass changelog text into the spec update step via an environment variable and printf to avoid injecting third-party text directly into shell script source.
- Deduplicate tracking issues by matching on exact issue titles rather than fuzzy search to avoid reusing mismatched issues.
- Trigger build-test CI for update PRs only when the PR was actually created or updated, and only if no pull_request workflow run already exists for the same head SHA.
- Correct a minor comment typo in the workflow configuration.